### PR TITLE
Fix builtins _dir and _out:

### DIFF
--- a/sys/p2_code.spin
+++ b/sys/p2_code.spin
@@ -161,7 +161,7 @@ pri __builtin_propeller_dirrnd(pin)
   endasm
 pri __builtin_propeller_dir(pin, c)
   asm
-    test   pin,#1 wc
+    test   c,#1 wc
     dirc pin
   endasm
 
@@ -205,7 +205,7 @@ pri __builtin_propeller_outrnd(pin)
   endasm
 pri __builtin_propeller_out(pin, c)
   asm
-    test   pin,#1 wc
+    test   c,#1 wc
     outc pin
   endasm
 


### PR DESCRIPTION
Hi Eric,

I'm a pasm noob so may be off, but I think these two were supposed to test against c, not pin. It seems to behave as I expected if I change it that way. Does this look right to you?
