### PR TITLE
Add spin.tab.h as a build dependency for spinc.o

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,7 +74,7 @@ LEXOBJS = $(LEXSRCS:%.c=$(BUILD)/%.o)
 SPINOBJS = $(SPINSRCS:%.c=$(BUILD)/%.o)
 OBJS = $(SPINOBJS) $(BUILD)/spin.tab.o $(BUILD)/basic.tab.o $(BUILD)/cgram.tab.o
 
-SPIN_CODE = sys/p1_code.spin.h sys/p2_code.spin.h sys/common.spin.h sys/float.spin.h sys/gcalloc.spin.h
+SPIN_CODE = sys/p1_code.spin.h sys/p2_code.spin.h sys/common.spin.h sys/float.spin.h sys/gcalloc.spin.h $(BUILD)/spin.tab.h
 PASM_SUPPORT_CODE = sys/lmm_orig.spin.h sys/lmm_slow.spin.h sys/lmm_trace.spin.h sys/lmm_cache.spin.h sys/lmm_compress.spin.h
 
 all: $(BUILD) $(PROGS)


### PR DESCRIPTION
Parallel `make -kj` on a clean tree failed on my machine with the following error, but it worked upon repeating the command.  This patch seems to fix it.
```
...
spinc.c:36:10: fatal error: spin.tab.h: No such file or directory                                                                                                                                                                              
   36 | #include "spin.tab.h"                                                                                          
      |          ^~~~~~~~~~~~                                                                                          
compilation terminated.                                                                                                                                                                                                                        
make: *** [Makefile:152: build/spinc.o] Error 1
```