### PR TITLE
Add CASE_FAST for bytecode... and some other stuff

### DIFF
--- a/ast.h
+++ b/ast.h
@@ -219,6 +219,7 @@ enum astkind {
     AST_GETHIGH = 155,
 
     AST_FUNC_NAME = 156,
+    AST_CASEEXPR = 157, // Represents the hidden variable in a bytecode CASE. Very terrible hack.
 };
 
 /* forward reference */

--- a/backends/bytecode/bcir.c
+++ b/backends/bytecode/bcir.c
@@ -102,8 +102,8 @@ void BIRB_AppendPending(BCIRBuffer *buf) {
     buf->pending->opCount = 0;
 }
 
-bool BCIR_SizeDetermined(ByteOpIR *ir) {
-    return ir->fixedSize || ir->kind == BOK_LABEL;
+static bool BCIR_SizeDetermined(ByteOpIR *ir) {
+    return ir->fixedSize >= 0;
 }
 
 void BCIR_GetJumpOffsetBounds(ByteOpIR *jump,bool func_relative,int *minDist, int *maxDist,int recursionsLeft) {
@@ -157,6 +157,8 @@ bool BCIR_UsesLabel(ByteOpIR *ir) {
     case BOK_JUMP_IF_Z:
     case BOK_JUMP_IF_NZ:
     case BOK_FUNDATA_PUSHADDRESS:
+    case BOK_FUNDATA_LOOKUPJUMP:
+    case BOK_FUNDATA_JUMPENTRY:
     case BOK_CASE:
     case BOK_CASE_RANGE:
         return true;
@@ -202,6 +204,13 @@ bool BCIR_IsTerminalOp(ByteOpIR *ir) {
     }
 }
 
+bool BCIR_CanBeOversized(ByteOpIR *ir) {
+    switch (ir->kind) {
+    case BOK_ALIGN: return false;
+    default: return true;
+    }
+}
+
 // Is this memOp constant (i.e. doesn't pop any values to determine its address)
 bool BCIR_IsConstMemOp(ByteOpIR *ir) {
     return ir->attr.memop.base != MEMOP_BASE_POP && !ir->attr.memop.popIndex && ir->mathKind != MOK_MOD_REPEATSTEP;
@@ -242,7 +251,7 @@ static bool BCIR_OptDeadCode() {
     bool didWork = false;
     for(ByteOpIR *ir = current_birb->head;ir;ir=ir->next) {
         if(BCIR_IsTerminalOp(ir)) {
-            while (ir->next && !BCIR_IsLabel(ir->next)) {
+            while (ir->next && !(BCIR_IsLabel(ir->next) || (ir->next->kind == BOK_ALIGN && ir->next->next && BCIR_IsLabel(ir->next->next)))) {
                 BIRB_Remove(current_birb,ir->next);
                 didWork = true;
             }
@@ -441,11 +450,19 @@ void BCIR_ResolveNamedLabels(BCIRBuffer *irbuf) {
             for (ByteOpIR *jr=irbuf->head;jr;jr=jr->next) {
                 if (BCIR_UsesLabel(jr) && jr->jumpTo->kind == BOK_NAMEDLABEL && !strcmp(name,jr->jumpTo->data.stringPtr)) {
                     int stackdiff = jr->jumpTo->attr.labelHiddenVars - lbl->attr.labelHiddenVars;
-                    if (stackdiff > 0) BCIR_InsertPopNBefore(irbuf,jr,stackdiff);
-                    else if (stackdiff < 0) ERROR(NULL,"Jump to named label with deeper stack");
+                    if (stackdiff > 0) {
+                        if (jr->kind == BOK_JUMP) BCIR_InsertPopNBefore(irbuf,jr,stackdiff);
+                        else ERROR(NULL,"Named label reference to %s with uneven stack depth",name);
+                    } else if (stackdiff < 0) ERROR(NULL,"Jump to named label %s with deeper stack",name);
                     jr->jumpTo = lbl;
                 }
             }
+        }
+    }
+    // Check for any unresolved labels
+    for (ByteOpIR *jr=irbuf->head;jr;jr=jr->next) {
+        if (BCIR_UsesLabel(jr) && jr->jumpTo->kind == BOK_NAMEDLABEL) {
+            ERROR(NULL,"unresolved label %s in function %s",jr->jumpTo->data.stringPtr,curfunc->name);
         }
     }
 }
@@ -462,7 +479,7 @@ BCIR_DetermineSizes(BCIRBuffer *irbuf,bool force,int maxRecursion) {
         if (min==max) {
             ir->fixedSize = max;
             didSomething = true;
-        } else if (force) {
+        } else if (force && BCIR_CanBeOversized(ir)) {
             ir->fixedSize = max;
             return true;
         }
@@ -482,6 +499,7 @@ BCIR_AllDetermined(BCIRBuffer *irbuf) {
 
 static void
 BCIR_Compact(BCIRBuffer *irbuf,int maxRecursion) {
+    for(ByteOpIR *ir=irbuf->head;ir;ir=ir->next) ir->fixedSize = -1; // Initialize all sizes to -1
     for(;;) {
         // Fix sizes until we cant anymore
         while (BCIR_DetermineSizes(irbuf,false,maxRecursion));

--- a/backends/bytecode/bcir.c
+++ b/backends/bytecode/bcir.c
@@ -461,8 +461,10 @@ void BCIR_ResolveNamedLabels(BCIRBuffer *irbuf) {
     }
     // Check for any unresolved labels
     for (ByteOpIR *jr=irbuf->head;jr;jr=jr->next) {
-        if (BCIR_UsesLabel(jr) && jr->jumpTo->kind == BOK_NAMEDLABEL) {
-            ERROR(NULL,"unresolved label %s in function %s",jr->jumpTo->data.stringPtr,curfunc->name);
+        if (BCIR_UsesLabel(jr)) {
+            if (jr->jumpTo) {
+                if (jr->jumpTo->kind == BOK_NAMEDLABEL) ERROR(NULL,"unresolved label %s in function %s",jr->jumpTo->data.stringPtr,curfunc->name);
+            } else ERROR(NULL,"Internal Error: Missing label in function %s",curfunc->name);
         }
     }
 }

--- a/backends/bytecode/bcir.h
+++ b/backends/bytecode/bcir.h
@@ -12,6 +12,8 @@
     X(LABEL) /* Virtual jump target opcode */\
     X(NAMEDLABEL) /* For arbitrary GOTO, gets converted to LABEL early on. Also allocated loose as a jump target */\
     \
+    X(ALIGN) \
+    \
     X(CONSTANT)  /* Push immediate */\
     X(POP)  /* Pop N/4 values */\
     \
@@ -26,7 +28,9 @@
     X(MEM_ADDRESS)  /* Push effective address */\
     \
     X(FUNDATA_PUSHADDRESS) /* Absolute address of function-relative labeled data (such as STRING) */ \
+    X(FUNDATA_LOOKUPJUMP) /* read(!) value from a jump table with popped index */\
     X(FUNDATA_STRING) \
+    X(FUNDATA_JUMPENTRY) \
     \
     X(ANCHOR) /* Set up stack frame for call */\
     \
@@ -232,7 +236,6 @@ ByteOpIR *BIRB_PushCopy(BCIRBuffer *buf,ByteOpIR *ir);
 void BIRB_InsertBefore(BCIRBuffer *buf,ByteOpIR *target,ByteOpIR *ir);
 void BIRB_AppendPending(BCIRBuffer *buf);
 
-bool BCIR_SizeDetermined(ByteOpIR *ir);
 void BCIR_GetJumpOffsetBounds(ByteOpIR *jump,bool func_relative,int *minDist, int *maxDist,int recursionsLeft);
 int BCIR_GetJumpOffset(ByteOpIR *jump,bool func_relative);
 

--- a/backends/bytecode/outbc.c
+++ b/backends/bytecode/outbc.c
@@ -657,17 +657,32 @@ BCCompileMemOpExEx(BCIRBuffer *irbuf,AST *node,BCContext context, enum MemOpKind
         type = ast_type_long;
     else type = RemoveTypeModifiers(BaseType(type));
     
-    // FIXME: should we actually use TYPESIZE here rather than relying on
-    // particular types?
-         if (type == ast_type_byte) memOp.attr.memop.memSize = MEMOP_SIZE_BYTE;
-    else if (type == ast_type_word) memOp.attr.memop.memSize = MEMOP_SIZE_WORD; 
-    else if (type == ast_type_long) memOp.attr.memop.memSize = MEMOP_SIZE_LONG;
-    // \/ hack \/
-    else if (type == ast_type_unsigned_long && (kind != MEMOP_MODIFY || modifyMathKind == MOK_MOD_WRITE)) memOp.attr.memop.memSize = MEMOP_SIZE_LONG;
-    else if (type == NULL) memOp.attr.memop.memSize = MEMOP_SIZE_LONG; // Assume long type... This is apparently neccessary
-    else {
-        ERROR(node,"Can't figure out mem op type, is unhandled");
-        printASTInfo(type);
+    if (!type) type = ast_type_long;
+
+    switch (type->kind) {
+    case AST_UNSIGNEDTYPE: {
+        int size = type->left->d.ival;
+        switch (size) {
+        case 1: memOp.attr.memop.memSize = MEMOP_SIZE_BYTE; break;
+        case 2: memOp.attr.memop.memSize = MEMOP_SIZE_WORD; break;
+        // Technically treated as signed, but all the unsigned operators are seperate, anyways, so I guess it's fine?
+        case 4: memOp.attr.memop.memSize = MEMOP_SIZE_LONG; break; 
+        default: ERROR(node,"Can't handle unsigned type with size %d",size); break;
+        }
+    } break;
+    case AST_INTTYPE: {
+        int size = type->left->d.ival;
+        switch (size) {
+        // Will need to generate a sign-extend for these, somehow
+        case 1: if (kind == MEMOP_WRITE) memOp.attr.memop.memSize = MEMOP_SIZE_BYTE; else goto signed_todo; break;
+        case 2: if (kind == MEMOP_WRITE) memOp.attr.memop.memSize = MEMOP_SIZE_WORD; else goto signed_todo; break;
+        case 4: memOp.attr.memop.memSize = MEMOP_SIZE_LONG; break; 
+        signed_todo:
+        default: ERROR(node,"Can't handle signed type with size %d",size); break;
+        }
+    } break;
+    default:
+        ERROR(node,"Unhandled type kind %d",type->kind);
     }
 
     after_typeinfer:
@@ -777,7 +792,7 @@ BCCompileMemOp(BCIRBuffer *irbuf,AST *node,BCContext context, enum MemOpKind kin
 
 static void
 BCCompileAssignment(BCIRBuffer *irbuf,AST *node,BCContext context,bool asExpression,enum MathOpKind modifyMathKind) {
-    ASSERT_AST_KIND(node,AST_ASSIGN,;);
+    ASSERT_AST_KIND(node,AST_ASSIGN,return;);
     AST *left = node->left, *right = node->right;
     bool modifyReverseMath = false;
 
@@ -889,6 +904,9 @@ BCCompileAssignment(BCIRBuffer *irbuf,AST *node,BCContext context,bool asExpress
     AST *memopNode = NULL;
 
     switch(left->kind) {
+    case AST_EMPTY:
+        if (asExpression || ExprHasSideEffects(right)) BCCompileExpression(irbuf,right,context,!asExpression);
+        return;
     case AST_RANGEREF:
     case AST_HWREG: {
         memopNode = left;
@@ -1377,6 +1395,19 @@ BCCompileExpression(BCIRBuffer *irbuf,AST *node,BCContext context,bool asStateme
                     if (IsConstExpr(right) && EvalConstExpr(right) == 0) goto noOp;
                     mok = MOK_ADD;
                     break;
+
+                case K_LIMITMAX_UNS:
+                case K_LIMITMIN_UNS: {
+                    // TODO: don't do this nonsense when there's a native op for this
+                    // also TODO: optimize to signed limit if possible
+                    BCCompileExpression(irbuf,AstOperator('+',
+                        AstOperator(optoken == K_LIMITMAX_UNS ? K_LIMITMAX : K_LIMITMIN,
+                            AstOperator('+',left,AstInteger(1U<<31)),
+                            AstOperator('+',right,AstInteger(1U<<31))
+                    ),AstInteger(1U<<31)),context,asStatement);
+
+                    return;
+                } break;
 
                 case K_SIGNEXTEND:
                 case K_ZEROEXTEND:
@@ -1868,6 +1899,7 @@ BCCompileStatement(BCIRBuffer *irbuf,AST *node, BCContext context) {
 
         BCContext newcontext = context;
         newcontext.hiddenVariables += 2;
+        newcontext.caseVarsAt = newcontext.hiddenVariables;
 
         // Preview what we got
         int cases = 0;
@@ -1944,11 +1976,8 @@ BCCompileStatement(BCIRBuffer *irbuf,AST *node, BCContext context) {
         for(AST *list=node->right;list;list=list->right) {
             AST *item = list->left;
             if (item->kind == AST_COMMENTEDNODE) item = item->left;
-            if (item->kind == AST_ENDCASE) {
-                //printf("Got AST_ENDCASE\n");
-                ByteOpIR endOp = {.kind = BOK_CASE_DONE};
-                BIRB_PushCopy(irbuf,&endOp);
-            } else if (item->kind == AST_CASEITEM || item->kind == AST_OTHER) {
+
+            if (item->kind == AST_CASEITEM || item->kind == AST_OTHER) {
                 bool isOther = item->kind == AST_OTHER;
                 //printf(isOther ? "Got AST_OTHER\n" : "Got AST_CASEITEM\n");
                 BIRB_Push(irbuf,isOther?otherlabel:caselabels[whichcase]);
@@ -1973,6 +2002,43 @@ BCCompileStatement(BCIRBuffer *irbuf,AST *node, BCContext context) {
         BIRB_Push(irbuf,endlabel);
 
     } break;
+    case AST_JUMPTABLE: {
+        ASSERT_AST_KIND(node->left,AST_ASSIGN,return;);
+        ASSERT_AST_KIND(node->left->left,AST_CASEEXPR,return;);
+        
+        ByteOpIR align = {.kind = BOK_ALIGN,.data.int32 = 2};
+        if (!gl_p2) BIRB_PushCopy(irbuf->pending,&align); // P2 doesn't need alignment
+        ByteOpIR *tableLabel = BCNewOrphanLabel(context);
+        BIRB_Push(irbuf->pending,tableLabel);
+
+        ByteOpIR *endLabel = BCNewOrphanLabel(context);
+
+        BCContext newcontext = context;
+        newcontext.hiddenVariables += 2;
+        newcontext.caseVarsAt = newcontext.hiddenVariables;
+
+        ByteOpIR pushDoneAddr = {.kind = BOK_FUNDATA_PUSHADDRESS,.jumpTo=endLabel};
+        BIRB_PushCopy(irbuf,&pushDoneAddr);
+        BCCompileInteger(irbuf,0); // Fake index var so we can use CASE_DONE
+
+        BCCompileExpression(irbuf,node->left->right,context,false);
+        ByteOpIR lookupOp = {.kind = BOK_FUNDATA_LOOKUPJUMP,.jumpTo=tableLabel};
+        BIRB_PushCopy(irbuf,&lookupOp);
+        // There's no straightup "jump to value+PBASE". CASE_DONE does it, but we need to push a dummy value first
+        BCCompileInteger(irbuf,0);
+        ByteOpIR jumpOp = {.kind = BOK_CASE_DONE};
+        BIRB_PushCopy(irbuf,&jumpOp);
+
+        AST *ast = node->right;
+        for (;ast&&ast->kind==AST_LISTHOLDER;ast=ast->right) {
+            const char *name = GetUserIdentifierName(ast->left);
+            if (!name) ERROR(ast,"Can't get name of label");
+            ByteOpIR jumpEntry = {.kind = BOK_FUNDATA_JUMPENTRY,.jumpTo = BCNewNamedLabelRef(newcontext,name)};
+            BIRB_PushCopy(irbuf->pending,&jumpEntry);
+        }
+        if (ast) BCCompileStmtlist(irbuf,ast,newcontext);
+        BIRB_Push(irbuf,endLabel);
+    } break;
     case AST_FUNCCALL: {
         BCCompileFunCall(irbuf,node,context,false,false);
     } break;
@@ -1992,6 +2058,12 @@ BCCompileStatement(BCIRBuffer *irbuf,AST *node, BCContext context) {
         } else {
             BCCompileJump(irbuf,context.quitLabel,context);
         }
+    } break;
+    case AST_ENDCASE: {
+        if (context.caseVarsAt < 0) ERROR(node,"ENDCASE outside of a CASE");
+        BCCompilePopN(irbuf,context.hiddenVariables - context.caseVarsAt);
+        ByteOpIR doneOp = {.kind = BOK_CASE_DONE};
+        BIRB_PushCopy(irbuf,&doneOp);
     } break;
     case AST_LOCAL_IDENTIFIER:
     case AST_IDENTIFIER: {
@@ -2097,7 +2169,7 @@ BCCompileFunction(ByteOutputBuffer *bob,Function *F) {
         ERROR(F->body,"Internal Error: Expected AST_STMTLIST, got id %d",F->body->kind);
         return;
     } else {
-        BCContext context = {0};
+        BCContext context = {.caseVarsAt = -1};
         BCCompileStmtlist(&irbuf,F->body,context);
     }
     // Always append a return (TODO: only when neccessary)

--- a/backends/bytecode/outbc.c
+++ b/backends/bytecode/outbc.c
@@ -235,8 +235,7 @@ static bool CanUseEitherSignedOrUnsigned(AST *node) {
     printf("In CanUseEitherSignedOrUnsigned...\n");DumpAST(node);
     AST *type = ExprType(node);
     if (type) {
-        // FIXME: ExprType seems to return bogus values
-        //if (type->kind == AST_UNSIGNEDTYPE && type->left->d.ival < LONG_SIZE) return true;
+        if (type->kind == AST_UNSIGNEDTYPE && type->left->d.ival < LONG_SIZE) return true;
     }
     if (node->kind == AST_OPERATOR) {
         int32_t constVal;

--- a/backends/bytecode/outbc.h
+++ b/backends/bytecode/outbc.h
@@ -22,6 +22,11 @@ enum MemOpKind {
     MEMOP_READ,MEMOP_WRITE,MEMOP_MODIFY,MEMOP_ADDRESS
 };
 
+bool interp_can_multireturn();
+bool interp_can_unsigned();
+
+bool CanUseEitherSignedOrUnsigned(AST *node);
+
 void OutputByteCode(const char *fname, Module *P);
 
 #endif

--- a/backends/bytecode/outbc.h
+++ b/backends/bytecode/outbc.h
@@ -14,6 +14,7 @@
 
 typedef struct {
     int hiddenVariables; // Count of hidden variables on stack
+    int caseVarsAt; // Where the nearest case has its hidden variables
     ByteOpIR *quitLabel,*nextLabel;
 } BCContext;
 

--- a/cmdline.c
+++ b/cmdline.c
@@ -374,6 +374,7 @@ static struct optflag_table {
     { "inline-single", OPT_INLINE_SINGLEUSE },
     { "cse", OPT_PERFORM_CSE },
     { "remove-bss", OPT_REMOVE_HUB_BSS },
+    { "casetable", OPT_CASETABLE },
     { "all", OPT_FLAGS_ALL },
 };
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))

--- a/frontends/basic/basiclang.c
+++ b/frontends/basic/basiclang.c
@@ -849,7 +849,7 @@ doBasicTransform(AST **astptr)
             doBasicTransform(&caseitem->right);
             list = list->right;
         }
-        *ast = *CreateSwitch(ast->left, ast->right, case_name);
+        *ast = *CreateSwitch(ast, case_name);
         AstReportDone(&saveinfo);
         break;
     }        

--- a/frontends/c/clang.c
+++ b/frontends/c/clang.c
@@ -139,7 +139,7 @@ doCTransform(AST **astptr, unsigned cflags)
     case AST_CASE:
         doCTransform(&ast->left, cflags);
         doCTransform(&ast->right, cflags);
-        *ast = *CreateSwitch(ast->left, ast->right, NULL);
+        *ast = *CreateSwitch(ast, NULL);
         break;
     case AST_LOCAL_IDENTIFIER:
     case AST_IDENTIFIER:

--- a/frontends/common.h
+++ b/frontends/common.h
@@ -876,7 +876,7 @@ void DeclareTypedGlobalVariables(AST *ast, int inDat);
 void AddSymbolForLabel(AST *ast);
 
 /* transform a switch/case expression into a sequence of GOTOs */
-AST *CreateSwitch(AST *expr, AST *stmt, const char *force_reason);
+AST *CreateSwitch(AST *origast, const char *force_reason);
 
 // check to see if module is top level
 int IsTopLevel(Module *P);

--- a/frontends/common.h
+++ b/frontends/common.h
@@ -156,6 +156,7 @@ extern int gl_optimize_flags; /* flags for optimization */
 #define OPT_CONST_PROPAGATE     0x000800  /* constant propagation */
 #define OPT_LOOP_BASIC          0x001000  /* simple loop conversion */
 #define OPT_TAIL_CALLS          0x002000  /* tail call optimization */
+#define OPT_CASETABLE           0x004000  /* convert CASE to CASE_FAST (only for bytecode mode) */
 
 #define OPT_FLAGS_ALL           0xffffff
 #define OPT_ASM_BASIC  (OPT_BASIC_REGS|OPT_BRANCHES|OPT_PEEPHOLE|OPT_CONST_PROPAGATE)                        

--- a/frontends/spin/spinlang.c
+++ b/frontends/spin/spinlang.c
@@ -637,9 +637,7 @@ doSpinTransform(AST **astptr, int level, AST *parent)
             doSpinTransform(&caseitem->right, level, ast);
             list = list->right;
         }
-        if (gl_output != OUTPUT_BYTECODE) {
-            *ast = *CreateSwitch(ast->left, ast->right, case_name);
-        }
+        *ast = *CreateSwitch(ast, case_name);
         AstReportDone(&saveinfo);
         break;
     }


### PR DESCRIPTION
- CASE_FAST in bytecode mode
- `-Ocasetable` to enable conversion of standard CASE to jumptable (not always advantageous)
- Fixed zerox->and optimization
- Optimize unsigned operators where possible
- Optimize nested add/sub of constants
- Other operator optimizations
- A couple minor fixes