### PR TITLE
Stop CI trying to run hardware tests

### DIFF
--- a/.github/workflows/c-cpp.yml
+++ b/.github/workflows/c-cpp.yml
@@ -35,4 +35,4 @@ jobs:
      - name: make
        run: make
      - name: test
-       run: make test
+       run: make test_offline

--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,8 @@ preproc: preprocess.c $(UTIL)
 clean:
 	$(RM) $(PROGS) $(BUILD)/* *.zip
 
-test: lextest asmtest cpptest errtest p2test runtest
+test_offline: lextest asmtest cpptest errtest p2test
+test: test_offline runtest
 #test: lextest asmtest cpptest errtest runtest
 
 lextest: $(PROGS)


### PR DESCRIPTION
Apparently `runtests.sh` doesn't set an error code, so I never noticed the CI was always trying to run the hardware tests....