### PR TITLE
Add size optimizations

### DIFF
--- a/backends/bytecode/outbc.c
+++ b/backends/bytecode/outbc.c
@@ -1384,6 +1384,7 @@ const char *BCgetNameForOBJID(Module *M,int id) {
     ASSERT_AST_KIND(obj,AST_DECLARE_VAR,return 0;);
     ASSERT_AST_KIND(obj->right,AST_LISTHOLDER,return 0;);
     AST *ident = obj->right->left;
+    if (ident && ident->kind == AST_ARRAYDECL) ident = ident->left;
     ASSERT_AST_KIND(ident,AST_IDENTIFIER,return 0;);
     return GetIdentifierName(ident);
 }

--- a/cmdline.c
+++ b/cmdline.c
@@ -375,6 +375,7 @@ static struct optflag_table {
     { "cse", OPT_PERFORM_CSE },
     { "remove-bss", OPT_REMOVE_HUB_BSS },
     { "casetable", OPT_CASETABLE },
+    { "extrasmall", OPT_EXTRASMALL },
     { "all", OPT_FLAGS_ALL },
 };
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))
@@ -411,8 +412,10 @@ int ParseOptimizeString(AST *line, const char *str, int *flag_ptr)
                 flags = 0;
                 continue;
             case '1':
-            case 's':
                 flags = DEFAULT_ASM_OPTS;
+                continue;
+            case 's':
+                flags = DEFAULT_ASM_OPTS | OPT_EXTRASMALL;
                 continue;
             case '2':
             case '3':

--- a/frontends/common.h
+++ b/frontends/common.h
@@ -157,6 +157,7 @@ extern int gl_optimize_flags; /* flags for optimization */
 #define OPT_LOOP_BASIC          0x001000  /* simple loop conversion */
 #define OPT_TAIL_CALLS          0x002000  /* tail call optimization */
 #define OPT_CASETABLE           0x004000  /* convert CASE to CASE_FAST (only for bytecode mode) */
+#define OPT_EXTRASMALL          0x008000  /* Use smaller-but-slower constructs */
 
 #define OPT_FLAGS_ALL           0xffffff
 #define OPT_ASM_BASIC  (OPT_BASIC_REGS|OPT_BRANCHES|OPT_PEEPHOLE|OPT_CONST_PROPAGATE)                        


### PR DESCRIPTION
Using -Os or -Oextrasmall will now enable two size-for-speed tradeoffs. That is, disabling folding of bool operators into multiple conditional jumps and a smaller encoding for negative constants. These aren't all that effective, usually saving 0..32 bytes on a large program (keep in mind flexspin -O1 is already very small), but the constant thing is something BSTC can do, so it's a good thing to make that more obsolete, I think.

Also contains a bugfix for object arrays and some more boolean operator optimizations.