### PR TITLE
Allow dynamic sign/zero extend on P1

### DIFF
--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -2444,7 +2444,6 @@ CompileBasicOperator(IRList *irl, AST *expr, Operand *dest)
           EmitMove(irl, temp, left);
           EmitOp2(irl, op == K_ZEROEXTEND ? OPC_ZEROX : OPC_SIGNX, temp, right);
       } else { // P1
-          //int shift = 32 - EvalConstExpr(rhs);
           AST *rhs_temp = FoldIfConst(AstOperator('-',AstInteger(32),rhs));
           left = CompileExpression(irl, lhs, temp);
           EmitMove(irl, temp, left);

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -2447,7 +2447,7 @@ CompileBasicOperator(IRList *irl, AST *expr, Operand *dest)
           AST *rhs_temp = FoldIfConst(AstOperator('-',AstInteger(32),rhs));
           left = CompileExpression(irl, lhs, temp);
           EmitMove(irl, temp, left);
-          if (op == K_ZEROEXTEND && rhs_temp->kind == AST_INTEGER && rhs_temp->d.ival >= 23) {
+          if (op == K_ZEROEXTEND && rhs_temp->kind == AST_INTEGER && (rhs_temp->d.ival&31) >= 23) {
               EmitOp2(irl, OPC_AND, temp, NewImmediate(0xFFFFFFFFu>>rhs_temp->d.ival));
           } else {
               right = CompileExpression(irl, rhs_temp, NULL);

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -2448,7 +2448,7 @@ CompileBasicOperator(IRList *irl, AST *expr, Operand *dest)
           left = CompileExpression(irl, lhs, temp);
           EmitMove(irl, temp, left);
           if (op == K_ZEROEXTEND && rhs_temp->kind == AST_INTEGER && (rhs_temp->d.ival&31) >= 23) {
-              EmitOp2(irl, OPC_AND, temp, NewImmediate(0xFFFFFFFFu>>rhs_temp->d.ival));
+              EmitOp2(irl, OPC_AND, temp, NewImmediate(0xFFFFFFFFu>>(rhs_temp->d.ival&31)));
           } else {
               right = CompileExpression(irl, rhs_temp, NULL);
               EmitOp2(irl, OPC_SHL, temp, right);


### PR DESCRIPTION
Optimizer really doesn't like the resulting `32 - (x+1)` expression, but oh well. Also extended the constant zerox to AND optimization to work for anything that'd fit an immediate.