### PR TITLE
Make lone CORDIC fix more agressive

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -3363,7 +3363,7 @@ static bool IsCordicGet(IR *ir) {
 // Thus, we shall remove these.
 static bool
 FixupLoneCORDIC(IRList *irl) {
-    bool seenCommand = false, change = false;
+    bool seenCommand = true, change = false;
     for(IR *ir=irl->tail;ir;ir=ir->prev) {
         if (IsCordicCommand(ir)) {
             if (seenCommand && !InstrIsVolatile(ir)) {
@@ -3371,8 +3371,10 @@ FixupLoneCORDIC(IRList *irl) {
                 DeleteIR(irl,ir);
                 change = true;
             } else seenCommand = true;
-        } else if (IsCordicGet(ir)||IsBranch(ir)||IsLabel(ir)) {
+        } else if (IsCordicGet(ir)) {
             seenCommand = false;
+        } else if (IsBranch(ir)||IsLabel(ir)) {
+            seenCommand = true;
         }
     }
     return change;


### PR DESCRIPTION
Now also fixes the issue when the unused command is followed by a branch or the end of the function. Should hopefully not explode anything, still.