### PR TITLE
Accurate IsDeadAfter for result regs

### DIFF
--- a/backends/asm/compress_ir.c
+++ b/backends/asm/compress_ir.c
@@ -59,6 +59,7 @@ IsSimple9BitOperand(Operand *op)
     case REG_REG:
     case REG_LOCAL:
     case REG_ARG:
+    case REG_RESULT:
         return 1;
     default:
         return 0;

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -746,7 +746,7 @@ doIsDeadAfter(IR *instr, Operand *op, int level, IR **stack)
         }
     }
     if (ir->opc == OPC_RET && ir->cond == COND_TRUE) {
-      return IsLocalOrArg(op);
+      goto done;
     } else if (ir->opc == OPC_CALL) {
         if (!IsLocal(op)) {
             // we know of some special cases where argN is not used

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -76,6 +76,15 @@ InstrReadsDst(IR *ir)
   case OPC_WRZ:
   case OPC_WRNZ:
     return false;
+  case OPC_MUXC:
+  case OPC_MUXNC:
+  case OPC_MUXZ:
+  case OPC_MUXNZ:
+    if (ir->src && ir->src->kind == IMM_INT && (int32_t)ir->src->val == -1) {
+        return false;
+    } else {
+        return true;
+    }
   default:
     break;
   }

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -431,7 +431,7 @@ Operand *GetResultReg(int n)
     }
     if (!resultreg[n]) {
         sprintf(rvalname, "result%d", n+1);
-        resultreg[n] = GetOneGlobal(REG_REG, strdup(rvalname), 0);
+        resultreg[n] = GetOneGlobal(REG_RESULT, strdup(rvalname), 0);
     }
     return resultreg[n];
 }
@@ -3124,6 +3124,7 @@ IsCogMem(Operand *addr)
     case REG_TEMP:
     case REG_LOCAL:
     case REG_ARG:
+    case REG_RESULT:
     case REG_SUBREG:
         return true;
     case IMM_HUB_LABEL:
@@ -3175,6 +3176,7 @@ OffsetMemory(IRList *irl, Operand *base, Operand *offset, AST *type)
         case REG_LOCAL:
         case REG_TEMP:
         case REG_ARG:
+        case REG_RESULT:
         case REG_HW:
 #if 1      
             /* special case immediate offsets */
@@ -3250,6 +3252,7 @@ ApplyArrayIndex(IRList *irl, Operand *base, Operand *offset, int siz)
         case REG_LOCAL:
         case REG_TEMP:
         case REG_ARG:
+        case REG_RESULT:
         case REG_HW:
 #if 1      
             /* special case immediate offsets */
@@ -3431,6 +3434,7 @@ GetLea(IRList *irl, Operand *src)
         case REG_LOCAL:
         case REG_TEMP:
         case REG_ARG:
+        case REG_RESULT:
         case REG_HW:
             src->used = 1;
             addr = NewOperand(IMM_COG_LABEL, src->name, offset);

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -1500,6 +1500,8 @@ static void EmitFunctionProlog(IRList *irl, Function *func)
         }
         ValidateStackptr();
         tmp = GetResultReg(5); // we know this won't be used in the system functions
+        tmp = NewFunctionTempRegister();
+        int starttempreg = FuncData(curfunc)->curtempreg;
         // tmp = _gc_alloc_managed(framesize)
         EmitMove(irl, GetArgReg(0), framesize);
         EmitOp1(irl, OPC_CALL, allocfunc);
@@ -1514,6 +1516,7 @@ static void EmitFunctionProlog(IRList *irl, Function *func)
 
         // adjust stack pointer back
         EmitOp2(irl, OPC_SUB, stackptr, framesize);
+        FreeTempRegisters(irl,starttempreg);
     }
 }
 

--- a/instr.h
+++ b/instr.h
@@ -306,6 +306,7 @@ enum Operandkind {
     REG_HUBPTR, // a register which holds a hub address
     REG_COGPTR, // a register which holds a cog address
     REG_ARG,   // for an argument to a function
+    REG_RESULT, // for a function result
     REG_SUBREG, // for a sub-register: "name" holds the pointer to original reg, "val" is the offset
     
 #define IsRegister(kind) ((kind) >= REG_HW && (kind) <= REG_SUBREG)


### PR DESCRIPTION
Not sure if I put REG_RESULT into all the relevant switches and conditions, but seems good. Fixes #219.

Based on #245's branch because I forgot to change to master.