### PR TITLE
Fix FCACHE-ing loops at ends of leaf functions

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -4258,7 +4258,8 @@ LoopCanBeFcached(IRList *irl, IR *root, int size_left)
         return 0;
     }
     endlabel = endjmp;
-    while (endlabel->next && endlabel->next->opc == OPC_LABEL) {
+    // addr != 0 check is to avoid picking up return labels
+    while (endlabel->next && endlabel->next->opc == OPC_LABEL && endlabel->next->addr != 0) {
         endlabel = endlabel->next;
     }
     if (IsForwardJump(endjmp)) {


### PR DESCRIPTION
Was picking up the return label as endlabel and then choking on the addr being zero.