### PR TITLE
Make FuncUsesArg work with user leaf functions

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -847,7 +847,7 @@ static bool FuncUsesArg(Operand *func, Operand *arg)
         return true;
     } else if (func == mulfunc || func == unsmulfunc || func == divfunc || func == unsdivfunc) {
         return false;
-    } else if (func && func->val && (func->kind == IMM_COG_LABEL || func->kind == IMM_HUB_LABEL) && ((Function*)func->val)->is_leaf) {
+    } else if (func && func->val && (/*func->kind == IMM_COG_LABEL ||*/ func->kind == IMM_HUB_LABEL) && ((Function*)func->val)->is_leaf) {
         int numparams = ((Function*)func->val)->numparams;
         for (int i=0;i<numparams;i++) if (arg == GetArgReg(i)) return true;
         return false;

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -848,9 +848,9 @@ static bool FuncUsesArg(Operand *func, Operand *arg)
     } else if (func == mulfunc || func == unsmulfunc || func == divfunc || func == unsdivfunc) {
         return false;
     } else if (func && func->val && (/*func->kind == IMM_COG_LABEL ||*/ func->kind == IMM_HUB_LABEL) && ((Function*)func->val)->is_leaf) {
-        int numparams = ((Function*)func->val)->numparams;
-        for (int i=0;i<numparams;i++) if (arg == GetArgReg(i)) return true;
-        return false;
+        if (arg->kind != REG_ARG) return true; // subreg or smth
+        if (arg->val < ((Function*)func->val)->numparams) return true; // Arg used;
+        return false; // Arg not used
     }
     return true;
 }
@@ -1016,10 +1016,8 @@ doIsDeadAfter(IR *instr, Operand *op, int level, IR **stack)
 done:  
   /* if we reach the end without seeing any use */
   if (isResult(op)) {
-      int used = curfunc->numresults;
-      for(int i=0;i<used;i++) {
-          if (op == GetResultReg(i)) return false;
-      }
+      if (op->kind != REG_RESULT) return false; // subreg or smth else
+      if (op->val < curfunc->numresults) return false; // This is a defined result of this function
       return true;
   } else {
     return IsLocalOrArg(op);

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -843,8 +843,14 @@ extern Operand *mulfunc, *unsmulfunc, *divfunc, *unsdivfunc, *muldiva, *muldivb;
 
 static bool FuncUsesArg(Operand *func, Operand *arg)
 {
-    if (func == mulfunc || func == unsmulfunc || func == divfunc || func == unsdivfunc) {
-        return (arg == muldiva) || (arg == muldivb);
+    if (arg == muldiva || arg == muldivb) {
+        return true;
+    } else if (func == mulfunc || func == unsmulfunc || func == divfunc || func == unsdivfunc) {
+        return false;
+    } else if (func && func->val && (func->kind == IMM_COG_LABEL || func->kind == IMM_HUB_LABEL) && ((Function*)func->val)->is_leaf) {
+        int numparams = ((Function*)func->val)->numparams;
+        for (int i=0;i<numparams;i++) if (arg == GetArgReg(i)) return true;
+        return false;
     }
     return true;
 }

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -5180,7 +5180,7 @@ AssignOneFuncName(Function *f)
         }
 
         if (InCog(f)) {
-            FuncData(f)->asmname = NewOperand(IMM_COG_LABEL, fname, (intptr_t)f);
+            FuncData(f)->asmname = NewOperand(IMM_COG_LABEL, fname, 0/*(intptr_t)f*/);
             FuncData(f)->asmretname = NewOperand(IMM_COG_LABEL, frname, 0);
             if (fentername) {
                 FuncData(f)->asmentername = NewOperand(IMM_COG_LABEL, fentername, 0);

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -431,7 +431,7 @@ Operand *GetResultReg(int n)
     }
     if (!resultreg[n]) {
         sprintf(rvalname, "result%d", n+1);
-        resultreg[n] = GetOneGlobal(REG_RESULT, strdup(rvalname), 0);
+        resultreg[n] = GetOneGlobal(REG_RESULT, strdup(rvalname), n);
     }
     return resultreg[n];
 }
@@ -445,7 +445,7 @@ Operand *GetArgReg(int n)
     }
     if (!argreg[n]) {
         sprintf(rvalname, "arg%02d", n+1);
-        argreg[n] = GetOneGlobal(REG_ARG, strdup(rvalname), 0);
+        argreg[n] = GetOneGlobal(REG_ARG, strdup(rvalname), n);
     }
     return argreg[n];
 }

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -5180,13 +5180,13 @@ AssignOneFuncName(Function *f)
         }
 
         if (InCog(f)) {
-            FuncData(f)->asmname = NewOperand(IMM_COG_LABEL, fname, 0);
+            FuncData(f)->asmname = NewOperand(IMM_COG_LABEL, fname, (intptr_t)f);
             FuncData(f)->asmretname = NewOperand(IMM_COG_LABEL, frname, 0);
             if (fentername) {
                 FuncData(f)->asmentername = NewOperand(IMM_COG_LABEL, fentername, 0);
             }
         } else {
-            FuncData(f)->asmname = NewOperand(IMM_HUB_LABEL, fname, 0);
+            FuncData(f)->asmname = NewOperand(IMM_HUB_LABEL, fname, (intptr_t)f);
             FuncData(f)->asmretname = NewOperand(IMM_HUB_LABEL, frname, 0);
             if (fentername) {
                 FuncData(f)->asmentername = NewOperand(IMM_HUB_LABEL, fentername, 0);


### PR DESCRIPTION
Not sure if `Operand.val` is the most pertinent way to convey a pointer to the function (esp. since it IMM_COG_LABEL uses it as an offset already (is this ever actually needed?)). But I did change val for arg and result regs to indicate the ordinal (to get rid of repetitive calls to Get*Reg). This leads to the slight funny that the results initialize to their ordinal value. Do the results need to be initialized, anyways? Normally not, I'd think.