### PR TITLE
Use SUBX x,x in optimizer

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -3254,10 +3254,8 @@ OptimizePeepholes(IRList *irl)
         // ->
         //      subx x,x
         } else if (ir->cond == COND_C && isConstMove(ir,&tmp) && tmp == -1 && !InstrSetsAnyFlags(ir) && !IsHwReg(ir->dst)) {
-            NOTE(NULL,"got the thing");
             previr = FindPrevSetterForReplace(ir,ir->dst);
             if (previr && isConstMove(previr,&tmp) && tmp == 0) {
-                NOTE(NULL,"previr?");
                 ReplaceOpcode(ir,OPC_SUBX);
                 ir->src = ir->dst;
                 ir->cond = COND_TRUE;

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -3248,6 +3248,7 @@ OptimizePeepholes(IRList *irl)
         if (opc == OPC_MUXC && IsImmediateVal(ir->src,-1) && !InstrSetsAnyFlags(ir) && !IsHwReg(ir->dst)) {
             ReplaceOpcode(ir,OPC_SUBX);
             ir->src = ir->dst;
+            changed = 1;
             goto done;
         //      mov x,#0
         // if_c neg x,#1
@@ -3259,6 +3260,8 @@ OptimizePeepholes(IRList *irl)
                 ReplaceOpcode(ir,OPC_SUBX);
                 ir->src = ir->dst;
                 ir->cond = COND_TRUE;
+                DeleteIR(irl,previr); // For some reason deadcode doesn't always pick it up.
+                changed = 1;
                 goto done;
             }
         }

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -1814,6 +1814,10 @@ CanTestZero(int opc)
     case OPC_NEGNC:
     case OPC_NEGZ:
     case OPC_NEGNZ:
+    case OPC_MUXC:
+    case OPC_MUXNC:
+    case OPC_MUXZ:
+    case OPC_MUXNZ:
     case OPC_RDLONG:
     case OPC_RDBYTE:
     case OPC_RDWORD:
@@ -2046,7 +2050,7 @@ OptimizeMoves(IRList *irl)
             } else if (isMoveLikeOp(ir) && (stop_ir = FindPrevSetterForReplace(ir,ir->src)) && stop_ir->opc == OPC_MOV 
                 && !InstrIsVolatile(stop_ir) && !InstrSetsAnyFlags(stop_ir) && (ir->src==ir->dst||IsDeadAfter(ir,ir->src))) {
                 ir->src = stop_ir->src;
-                DeleteIR(irl,stop_ir);
+                if (ir->cond == COND_TRUE) DeleteIR(irl,stop_ir);
                 change = 1;
             }
             ir = ir_next;
@@ -3244,17 +3248,12 @@ OptimizePeepholes(IRList *irl)
 
         int32_t tmp;
 
-        // MUXC x,#-1 -> SUBX x,x
-        if (opc == OPC_MUXC && IsImmediateVal(ir->src,-1) && !InstrSetsAnyFlags(ir) && !IsHwReg(ir->dst)) {
-            ReplaceOpcode(ir,OPC_SUBX);
-            ir->src = ir->dst;
-            changed = 1;
-            goto done;
-        //      mov x,#0
-        // if_c neg x,#1
-        // ->
-        //      subx x,x
-        } else if (ir->cond == COND_C && isConstMove(ir,&tmp) && tmp == -1 && !InstrSetsAnyFlags(ir) && !IsHwReg(ir->dst)) {
+        // transform
+        //        mov x,#0
+        //   if_c neg x,#1
+        // to
+        //        subx x,x
+        if (ir->cond == COND_C && isConstMove(ir,&tmp) && tmp == -1 && !InstrSetsAnyFlags(ir) && !IsHwReg(ir->dst)) {
             previr = FindPrevSetterForReplace(ir,ir->dst);
             if (previr && isConstMove(previr,&tmp) && tmp == 0) {
                 ReplaceOpcode(ir,OPC_SUBX);
@@ -3290,7 +3289,7 @@ OptimizePeepholes(IRList *irl)
             previr = FindPrevSetterForReplace(ir,ir->dst);
             if (previr && (previr->opc == OPC_SHR || previr->opc == OPC_SAR) 
             && !InstrSetsAnyFlags(ir) && previr->src->kind == IMM_INT 
-            && (previr->src->val & ((1<<shift)-1)) == 0) {
+            && (previr->src->val & ((1<<shift)-1)) == 0 && ir->cond == COND_TRUE) {
                 which = (previr->src->val&31)>>shift;
                 DeleteIR(irl,previr);
                 changed = 1;
@@ -3632,7 +3631,7 @@ OptimizeP2(IRList *irl)
             ir_next = ir_next->next;
         }
         opc = ir->opc;
-        if (opc == OPC_ADDCT1 && IsImmediateVal(ir->src, 0)) {
+        if (opc == OPC_ADDCT1 && IsImmediateVal(ir->src, 0) && ir->cond == COND_TRUE) {
             previr = FindPrevSetterForReplace(ir, ir->dst);
             if (previr && previr->opc == OPC_ADD && !InstrSetsAnyFlags(previr)) {
                 // add foo, val / addct1 foo, #0 -> addct1 foo, val
@@ -5059,14 +5058,27 @@ static PeepholePattern pat_signex[] = {
 // wrc x; cmp x, #0 wz
 static PeepholePattern pat_wrc_cmp[] = {
     { COND_TRUE, OPC_WRC, PEEP_OP_SET|0, OPERAND_ANY, PEEP_FLAGS_P2 },
-    { COND_TRUE, OPC_CMP, PEEP_OP_MATCH|0, PEEP_OP_IMM|0, PEEP_FLAGS_P2|PEEP_FLAGS_WCZ_OK },
+    { COND_TRUE, OPC_CMP, PEEP_OP_MATCH|0, PEEP_OP_IMM|0, PEEP_FLAGS_P2|PEEP_FLAGS_WCZ_OK|PEEP_FLAGS_MUST_WZ },
     { 0, 0, 0, 0, PEEP_FLAGS_DONE }
 };
 
 // muxc x,#-1; cmp x, #0 wz
 static PeepholePattern pat_muxc_cmp[] = {
     { COND_TRUE, OPC_MUXC, PEEP_OP_SET|0, PEEP_OP_CLRMASK(0,0), PEEP_FLAGS_NONE },
-    { COND_TRUE, OPC_CMP, PEEP_OP_MATCH|0, PEEP_OP_IMM|0, PEEP_FLAGS_WCZ_OK },
+    { COND_TRUE, OPC_CMP, PEEP_OP_MATCH|0, PEEP_OP_IMM|0, PEEP_FLAGS_WCZ_OK|PEEP_FLAGS_MUST_WZ },
+    { 0, 0, 0, 0, PEEP_FLAGS_DONE }
+};
+
+// subx x,x; cmp x, #0 wz
+static PeepholePattern pat_subx_cmp[] = {
+    { COND_TRUE, OPC_SUBX, PEEP_OP_SET|0, PEEP_OP_MATCH|0, PEEP_FLAGS_NONE },
+    { COND_TRUE, OPC_CMP, PEEP_OP_MATCH|0, PEEP_OP_IMM|0, PEEP_FLAGS_WCZ_OK|PEEP_FLAGS_MUST_WZ },
+    { 0, 0, 0, 0, PEEP_FLAGS_DONE }
+};
+
+// muxc x,#-1 wz
+static PeepholePattern pat_muxc_wz[] = {
+    { COND_TRUE, OPC_MUXC, PEEP_OP_SET|0, PEEP_OP_CLRMASK(0,0), PEEP_FLAGS_WCZ_OK|PEEP_FLAGS_MUST_WZ },
     { 0, 0, 0, 0, PEEP_FLAGS_DONE }
 };
 
@@ -5481,9 +5493,11 @@ static int ReplaceExtend(int arg, IRList *irl, IR *ir)
     return 1;
 }
 //
-// looks at the sequence
-//   wrc x (or muxc x,#-1)
+// looks at the sequence (arg = 0)
+//   wrc x (or muxc x,#-1 or subx x,x)
 //   cmp x, #0 wz
+// or (arg = 1)
+//   muxc x,#-1 wz
 // and if possible deletes it and replaces subsequent uses of C with NZ
 //
 static int ReplaceWrcCmp(int arg, IRList *irl, IR *ir)
@@ -5495,7 +5509,7 @@ static int ReplaceWrcCmp(int arg, IRList *irl, IR *ir)
     if (InstrIsVolatile(ir0) || !ir1 || InstrIsVolatile(ir1)) {
         return 0;
     }
-    ir = ir1->next;
+    ir = arg == 0 ? ir1->next : ir0->next;
     for(lastir = ir; lastir; lastir = lastir->next) {
         if (!lastir || InstrIsVolatile(lastir)) {
             return 0;
@@ -5524,8 +5538,12 @@ static int ReplaceWrcCmp(int arg, IRList *irl, IR *ir)
     if (IsBranch(lastir)) {
         ReplaceZWithNC(lastir);
     }
-    if (IsDeadAfter(ir1,ir0->dst)) DeleteIR(irl, ir0);
-    DeleteIR(irl, ir1);
+    if (arg == 0) {
+        if (IsDeadAfter(ir1,ir0->dst)) DeleteIR(irl, ir0);
+        DeleteIR(irl, ir1);
+    } else {
+        if (IsDeadAfter(ir0,ir0->dst)) DeleteIR(irl,ir0);
+    }
     return 1;
 }
 
@@ -5910,6 +5928,8 @@ struct Peepholes {
     { pat_wrc_test, 0, ReplaceWrcTest },
 
     { pat_muxc_cmp, 0, ReplaceWrcCmp },
+    { pat_subx_cmp, 0, ReplaceWrcCmp },
+    { pat_muxc_wz, 1, ReplaceWrcCmp },
     
     { pat_rdbyte1, 2, RemoveNFlagged },
     { pat_rdword1, 2, RemoveNFlagged },


### PR DESCRIPTION
Another day, another funny micro-optimization.
It turns out that the best way to set a register to all zeroes/ones based on C flag is SUBX.
Also has some stuff to cope with MUX* being added to CanTestZero