### PR TITLE
Enable inline-single for -Os

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -459,7 +459,7 @@ int ParseOptimizeString(AST *line, const char *str, int *flag_ptr)
                 flags = DEFAULT_ASM_OPTS;
                 continue;
             case 's':
-                flags = DEFAULT_ASM_OPTS | OPT_EXTRASMALL;
+                flags = DEFAULT_ASM_OPTS | OPT_EXTRASMALL | OPT_INLINE_SINGLEUSE;
                 continue;
             case '2':
             case '3':


### PR DESCRIPTION
It usually makes the code a decent bit smaller, so I guess it should be enabled by default for -Os