### PR TITLE
Avoid FCACHEing wait loops

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2174,6 +2174,8 @@ HasSideEffectsOtherThanReg(IR *ir)
     case OPC_LOCKNEW:
     case OPC_LOCKRET:
     case OPC_LOCKSET:
+    case OPC_LOCKTRY:
+    case OPC_LOCKREL:
     case OPC_SETQ:
     case OPC_SETQ2:
     case OPC_WAITCNT:
@@ -2882,16 +2884,19 @@ ReplaceZWithNC(IR *ir)
     case OPC_GENERIC:
     case OPC_GENERIC_DELAY:
     case OPC_GENERIC_NR:
+    case OPC_RCL:
+    case OPC_RCR:
+    // Are the below really needed here?
     case OPC_LOCKNEW:
     case OPC_LOCKSET:
     case OPC_LOCKCLR:
     case OPC_LOCKRET:
+    case OPC_LOCKTRY:
+    case OPC_LOCKREL:
     case OPC_SETQ:
     case OPC_SETQ2:
     case OPC_PUSH:
     case OPC_POP:
-    case OPC_RCL:
-    case OPC_RCR:
         ERROR(NULL, "Internal error, unexpected use of C");
         break;
     default:
@@ -4140,6 +4145,8 @@ static bool IsReorderBarrier(IR *ir) {
     case OPC_LOCKNEW:
     case OPC_LOCKRET:
     case OPC_LOCKSET:
+    case OPC_LOCKTRY:
+    case OPC_LOCKREL:
     case OPC_WAITCNT:
     case OPC_WAITX:
     case OPC_COGSTOP:

--- a/frontends/lexer.c
+++ b/frontends/lexer.c
@@ -3471,9 +3471,9 @@ instr_p2[] = {
     { "cogid",  0x0d600001, P2_DST_CONST_OK,  OPC_COGID, FLAG_WC },
     { "cogstop",0x0d600003, P2_DST_CONST_OK,  OPC_COGSTOP, 0 },
     { "locknew",0x0d600004, DST_OPERAND_ONLY, OPC_LOCKNEW, FLAG_WC },
-    { "lockret",0x0d600005, P2_DST_CONST_OK, OPC_GENERIC_NR_NOFLAGS, 0 },
-    { "locktry",0x0d600006, P2_DST_CONST_OK, OPC_GENERIC_NR, FLAG_WC },
-    { "lockrel",0x0d600007, P2_DST_CONST_OK, OPC_GENERIC_NR, FLAG_WC },
+    { "lockret",0x0d600005, P2_DST_CONST_OK, OPC_LOCKRET, 0 },
+    { "locktry",0x0d600006, P2_DST_CONST_OK, OPC_LOCKTRY, FLAG_WC },
+    { "lockrel",0x0d600007, P2_DST_CONST_OK, OPC_LOCKREL, FLAG_WC },
 
     { "qlog",   0x0d60000e, P2_DST_CONST_OK, OPC_QLOG, 0 },
     { "qexp",   0x0d60000f, P2_DST_CONST_OK, OPC_QEXP, 0 },

--- a/instr.h
+++ b/instr.h
@@ -112,6 +112,8 @@ typedef enum IROpcode {
     OPC_GETWORD,
     OPC_HUBSET,
     OPC_JMPREL,
+    OPC_LOCKTRY,
+    OPC_LOCKREL,
     OPC_MULS,
     OPC_MULU,
     OPC_NOT,


### PR DESCRIPTION
Adds a heuristic to avoid caching of wait loops. i.e. stuff like
```spin
.loop
        rdlong temp,objptr wz
if_nz   jmp #.loop
```

This saves a bunch of cycles both in case that the wait condition has already happened (no fcache or branch overhead at all) and in the case the event has to be waited for (since execution immediately continues instead of having to return back into LMM/hubexc). ofc also saves some memory.

Also some minor bugfix in here: In some cases around LOCKREL there may have been bad optimization from assuming it doesn't write its destination (it does when WC is set)