### PR TITLE
Explicitly set -std=gnu11

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,7 +108,7 @@ endif
 
 # use make OPT=-g to compile for debug, OPT=-O1 for release
 OPT ?= -g
-CFLAGS = $(OPT) -Wall -fwrapv $(INC) $(DEFS)
+CFLAGS = $(OPT) -std=gnu11 -Wall -fwrapv $(INC) $(DEFS)
 #CFLAGS = -no-pie -pg -Wall -fwrapv $(INC) $(DEFS)
 #CFLAGS = -g -O0 -Wall -fwrapv -Wc++-compat -Werror $(INC) $(DEFS)
 LIBS = -lm


### PR DESCRIPTION
Should(TM) fix building on ancient (but not prehistoric) GCC versions. gnu11 is the default value in modern GCC, so no change there.