### PR TITLE
More optimization nonsense

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -206,7 +206,9 @@ runtest: $(PROGS)
 	(cd Test; ./runtests_p2.sh)
 
 test_spinsim:  $(PROGS)
-	(cd Test/spinsim; make; cd ..; ./runtests_p1.sh "" "./spinsim/build/spinsim -b -q"; ./runtests_bc.sh "" "./spinsim/build/spinsim -b -q")
+	(cd Test/spinsim; make) 
+	(cd Test; ./runtests_p1.sh "" "./spinsim/build/spinsim -b -q")
+	(cd Test; ./runtests_bc.sh "" "./spinsim/build/spinsim -b -q")
 
 $(BUILD)/spin2cpp$(EXT): spin2cpp.c cmdline.c $(OBJS)
 	$(CC) $(CFLAGS) -o $@ $^ $(LIBS)

--- a/Test/Expect/stest118.pasm
+++ b/Test/Expect/stest118.pasm
@@ -5,7 +5,7 @@ dat
 entry
 
 __float_fromuns
-	cmp	arg01, #0 wz
+	cmps	arg01, #0 wz
  if_ne	mov	result1, arg01
  if_ne	and	result1, #15
  if_ne	shr	arg01, #2

--- a/Test/Expect/stest247.pasm
+++ b/Test/Expect/stest247.pasm
@@ -117,13 +117,12 @@ LR__0005
 LR__0006
 	cmp	__system___float_mul_a_0008, #0 wz
  if_e	jmp	#LR__0008
-	shl	__system___float_mul_a_0008, #1
 LR__0007
+	shl	__system___float_mul_a_0008, #1
 	cmp	__system___float_mul_a_0008, imm_8388608_ wc
  if_b	mov	_system___float_mul_tmp002_, __system___float_mul_aexp_0010
  if_b	sub	_system___float_mul_tmp002_, #1
  if_b	mov	__system___float_mul_aexp_0010, _system___float_mul_tmp002_
- if_b	shl	__system___float_mul_a_0008, #1
  if_b	jmp	#LR__0007
 	jmp	#LR__0001
 LR__0008
@@ -137,11 +136,10 @@ LR__0008
 LR__0009
 	cmp	__system___float_mul_b_0009, #0 wz
  if_e	jmp	#LR__0011
-	shl	__system___float_mul_b_0009, #1
 LR__0010
+	shl	__system___float_mul_b_0009, #1
 	cmp	__system___float_mul_b_0009, imm_8388608_ wc
  if_b	sub	__system___float_mul_bexp_0011, #1
- if_b	shl	__system___float_mul_b_0009, #1
  if_b	jmp	#LR__0010
 	jmp	#LR__0002
 LR__0011
@@ -229,23 +227,21 @@ LR__0015
 	and	_var05, #1
 	shl	_var05, #31
 	or	_var02, _var05
-	shr	_var01, #1
 LR__0016
+	shr	_var01, #1
 	cmps	_var03, #0 wc
  if_ae	jmp	#LR__0017
 	cmp	_var01, #0 wz
- if_e	jmp	#LR__0017
-	mov	_var06, _var02
-	and	_var06, #1
-	add	_var03, #1
-	shr	_var02, #1
-	mov	_var07, _var01
-	and	_var07, #1
-	shl	_var07, #31
-	or	_var02, _var07
-	or	_var02, _var06
-	shr	_var01, #1
-	jmp	#LR__0016
+ if_ne	mov	_var06, _var02
+ if_ne	and	_var06, #1
+ if_ne	add	_var03, #1
+ if_ne	shr	_var02, #1
+ if_ne	mov	_var07, _var01
+ if_ne	and	_var07, #1
+ if_ne	shl	_var07, #31
+ if_ne	or	_var02, _var07
+ if_ne	or	_var02, _var06
+ if_ne	jmp	#LR__0016
 LR__0017
 	cmps	_var03, #0 wc
  if_ae	jmp	#LR__0019

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2617,15 +2617,36 @@ static void DumpIR(IRList *irl,int suscnt,...) {
 // Check for spurious deleted IR.
 // Should be fixed properly, but too lazy .
 static bool ValidIR(IRList *irl,IR* ir) {
-    if (
-        (ir->prev ? ir->prev->next : irl->head)!=ir
-     || (ir->next ? ir->next->prev : irl->tail)!=ir
-     ) {
-        DEBUG(NULL,"Instr. validity check failed in %s",curfunc->user_name);
+    // Check upwards
+    IR *tmp = ir;
+    int count = 0;
+    while (tmp->prev) {
+        if (tmp->prev->next != tmp) {
+            DEBUG(NULL,"Instr. validity check failed (bad next) after %d steps in %s",count,curfunc->user_name);
+            return false;
+        }
+        tmp = tmp->prev;
+        count++;
+    }
+    if (irl->head != tmp) {
+        DEBUG(NULL,"Instr. validity check failed (bad head) after %d steps in %s",count,curfunc->user_name);
         return false;
-     } else {
-        return true;
-     }
+    }
+    tmp = ir;
+    count = 0;
+    while (tmp->next) {
+        if (tmp->next->prev != tmp) {
+            DEBUG(NULL,"Instr. validity check failed (bad prev) after %d steps in %s",count,curfunc->user_name);
+            return false;
+        }
+        tmp = tmp->next;
+        count++;
+    }
+    if (irl->tail != tmp) {
+        DEBUG(NULL,"Instr. validity check failed (bad tail) after %d steps in %s",count,curfunc->user_name);
+        return false;
+    }
+    return true;
 }
 
 // Find common ops in branches and move them out

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2607,7 +2607,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
         if (ir->opc == OPC_JUMP && ir->cond != COND_TRUE && ir->aux) {
             // Check for common ops at top of branch
             IR *lbl = ir->aux;
-            if (lbl->opc == OPC_LABEL && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
+            if (lbl->opc == OPC_LABEL && lbl->prev && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
                 for (;;) {
                     IR *next_stay = ir->next;
                     while (next_stay && IsDummy(next_stay)) next_stay = next_stay->next;
@@ -2615,7 +2615,8 @@ int OptimizeBranchCommonOps(IRList *irl) {
                     while (next_jump && IsDummy(next_jump)) next_jump = next_jump->next;
 
                     if (SameIR(next_stay,next_jump) && next_stay->cond == next_jump->cond
-                    && !(InstrIsVolatile(next_stay)||InstrIsVolatile(next_jump))) {
+                    && !(InstrIsVolatile(next_stay)||InstrIsVolatile(next_jump))
+                    && !InstrSetsFlags(next_stay,FlagsUsedByCond(ir->cond))){
                         DeleteIR(irl,next_jump);
                         DoReorderBlock(irl,ir->prev,next_stay,next_stay);
                         change++;

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2680,7 +2680,8 @@ int OptimizeBranchCommonOps(IRList *irl) {
         } else if (ir->opc == OPC_LABEL && ir->aux) {
             // check for common ops at bottom of branch
             IR *jump = ir->aux;
-            if (jump->opc == OPC_JUMP && jump->cond == COND_TRUE) {
+            if (jump->opc == OPC_JUMP && jump->cond == COND_TRUE && jump->aux == ir && ValidIR(irl,jump)) {
+
                 for (;;) {
                     IR *prev_stay = ir->prev;
                     while (prev_stay && IsDummy(prev_stay)) prev_stay = prev_stay->prev;

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2607,7 +2607,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
         if (ir->opc == OPC_JUMP && ir->cond != COND_TRUE && ir->aux) {
             // Check for common ops at top of branch
             IR *lbl = ir->aux;
-            if (lbl->opc == OPC_LABEL && lbl->prev && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
+            if (lbl->opc == OPC_LABEL /*&& lbl->prev*/ && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
                 for (;;) {
                     IR *next_stay = ir->next;
                     while (next_stay && IsDummy(next_stay)) next_stay = next_stay->next;

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2627,7 +2627,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
                 }
             }
         
-        } /* else if (ir->opc == OPC_LABEL && ir->aux) {
+        } else if (ir->opc == OPC_LABEL && ir->aux) {
             // check for common ops at bottom of branch
             IR *jump = ir->aux;
             if (jump->opc == OPC_JUMP && jump->cond == COND_TRUE) {
@@ -2647,7 +2647,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
                     }
                 }
             }
-        } */
+        }
     }
     return change;
 }

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2607,7 +2607,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
         if (ir->opc == OPC_JUMP && ir->cond != COND_TRUE && ir->aux) {
             // Check for common ops at top of branch
             IR *lbl = ir->aux;
-            if (lbl->opc == OPC_LABEL && lbl->prev && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
+            if (lbl->opc == OPC_LABEL && lbl->aux == ir && lbl->prev && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
                 for (;;) {
                     IR *next_stay = ir->next;
                     while (next_stay && IsDummy(next_stay)) next_stay = next_stay->next;
@@ -2615,6 +2615,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
                     while (next_jump && IsDummy(next_jump)) next_jump = next_jump->next;
 
                     if (SameIR(next_stay,next_jump) && next_stay->cond == next_jump->cond
+                    && !IsPrefixOpcode(next_stay)
                     && !(InstrIsVolatile(next_stay)||InstrIsVolatile(next_jump))
                     && !InstrSetsFlags(next_stay,FlagsUsedByCond(ir->cond))){
                         DeleteIR(irl,next_jump);

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -171,7 +171,7 @@ static bool IsJump(IR *ir)
   }
 }
 
-static bool IsBranch(IR *ir)
+bool IsBranch(IR *ir)
 {
     return IsJump(ir) || ir->opc == OPC_CALL;
 }
@@ -2617,6 +2617,7 @@ static void DumpIR(IRList *irl,int suscnt,...) {
 
 // Check for spurious deleted IR.
 // Should be fixed properly, but too lazy .
+// EDIT: Is now fixed properly, but might be good to keep anyways?
 static bool ValidIR(IRList *irl,IR* ir) {
     // Check upwards
     if (

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2618,35 +2618,15 @@ static void DumpIR(IRList *irl,int suscnt,...) {
 // Should be fixed properly, but too lazy .
 static bool ValidIR(IRList *irl,IR* ir) {
     // Check upwards
-    IR *tmp = ir;
-    int count = 0;
-    while (tmp->prev) {
-        if (tmp->prev->next != tmp) {
-            DEBUG(NULL,"Instr. validity check failed (bad next) after %d steps in %s",count,curfunc->user_name);
-            return false;
-        }
-        tmp = tmp->prev;
-        count++;
-    }
-    if (irl->head != tmp) {
-        DEBUG(NULL,"Instr. validity check failed (bad head) after %d steps in %s",count,curfunc->user_name);
+    if (
+        (ir->prev ? ir->prev->next : irl->head)!=ir
+     || (ir->next ? ir->next->prev : irl->tail)!=ir
+     ) {
+        DEBUG(NULL,"Instr. validity check failed in %s",curfunc->user_name);
         return false;
-    }
-    tmp = ir;
-    count = 0;
-    while (tmp->next) {
-        if (tmp->next->prev != tmp) {
-            DEBUG(NULL,"Instr. validity check failed (bad prev) after %d steps in %s",count,curfunc->user_name);
-            return false;
-        }
-        tmp = tmp->next;
-        count++;
-    }
-    if (irl->tail != tmp) {
-        DEBUG(NULL,"Instr. validity check failed (bad tail) after %d steps in %s",count,curfunc->user_name);
-        return false;
-    }
-    return true;
+     } else {
+        return true;
+     }
 }
 
 // Find common ops in branches and move them out

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2624,7 +2624,8 @@ int OptimizeBranchCommonOps(IRList *irl) {
                     }
                 }
             }
-        } else if (ir->opc == OPC_LABEL && ir->aux) {
+        
+        } /* else if (ir->opc == OPC_LABEL && ir->aux) {
             // check for common ops at bottom of branch
             IR *jump = ir->aux;
             if (jump->opc == OPC_JUMP && jump->cond == COND_TRUE) {
@@ -2644,7 +2645,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
                     }
                 }
             }
-        }
+        } */
     }
     return change;
 }

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -2607,7 +2607,7 @@ int OptimizeBranchCommonOps(IRList *irl) {
         if (ir->opc == OPC_JUMP && ir->cond != COND_TRUE && ir->aux) {
             // Check for common ops at top of branch
             IR *lbl = ir->aux;
-            if (lbl->opc == OPC_LABEL /*&& lbl->prev*/ && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
+            if (lbl->opc == OPC_LABEL && lbl->prev && lbl->prev->opc == OPC_JUMP && lbl->prev->cond == COND_TRUE) {
                 for (;;) {
                     IR *next_stay = ir->next;
                     while (next_stay && IsDummy(next_stay)) next_stay = next_stay->next;

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -795,6 +795,12 @@ DeleteIR(IRList *irl, IR *ir)
   } else {
     irl->tail = prev;
   }
+
+  // Delete label back reference if present
+  if (IsBranch(ir) && ir->aux) {
+    IR *lbl = ir->aux;
+    if (lbl->opc == OPC_LABEL && lbl->aux == ir) lbl->aux = NULL;
+  }
 }
 
 // emit a machine instruction with no operands

--- a/backends/asm/outasm.h
+++ b/backends/asm/outasm.h
@@ -68,6 +68,7 @@ int  ExpandInlines(IRList *irl);
 void ReplaceOpcode(IR *ir, IROpcode op);
 
 bool IsDummy(IR *ir);
+bool IsBranch(IR *ir);
 bool IsValidDstReg(Operand *reg);
 bool SrcOnlyHwReg(Operand *reg);
 bool IsLocal(Operand *reg);


### PR DESCRIPTION
All these three variants now compile to
```
	rdbyte	arg01, #1
	rdbyte	arg02, #2
	cmpm	arg01, arg02 wc
	sumnc	outa, #1
```

The first one already did:
```spin
PUB main()
  if test(byte[1],byte[2])
    outa++
  else
    outa--

PUB test(a,b) : r | o
  asm
        cmpm a,b wc
        wrc r
  endasm
```

The second one required merging of NEGxx + ADD/SUB sequences into a SUMxx:
```spin
PUB main()
  outa += test(byte[1],byte[2]) ? 1 : -1

PUB test(a,b) : r | o
  asm
        cmpm a,b wc
        wrc r
  endasm
```

And the third variant required a more general IR transform that took forever to debug:
```spin
PUB main()
  outa := test(byte[1],byte[2]) ? outa+1 : outa-1

PUB test(a,b) : r | o
  asm
        cmpm a,b wc
        wrc r
  endasm
```

It seems that sometimes following the ir->aux of a label leads to an instruction that has been deleted. Too lazy and tired to fix it properly right now, so I just added a check that hopefully avoids this issue in all situations.
