### PR TITLE
Add aggressive memory opt flag

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -424,6 +424,7 @@ static struct optflag_table {
     { "special-functions", OPT_SPECIAL_FUNCS },
     { "cordic-reorder", OPT_CORDIC_REORDER},
     { "local-reuse", OPT_LOCAL_REUSE},
+    { "aggressive-mem", OPT_AGRESSIVE_MEM},
     { "all", OPT_FLAGS_ALL },
 };
 #define ARRAY_SIZE(a) (sizeof(a) / sizeof(a[0]))

--- a/frontends/common.h
+++ b/frontends/common.h
@@ -181,6 +181,7 @@ extern int gl_optimize_flags; /* flags for optimization */
 #define OPT_SPECIAL_FUNCS       0x040000  /* optimize some special functions like pinr and pinw */
 #define OPT_CORDIC_REORDER      0x080000  /* reorder instructions around CORDIC operations */
 #define OPT_LOCAL_REUSE         0x100000  /* reuse local registers inside functions */
+#define OPT_AGRESSIVE_MEM       0x200000  /* agressive load/store optimization */
 #define OPT_FLAGS_ALL           0xffffff
 
 #define OPT_ASM_BASIC  (OPT_BASIC_REGS|OPT_BRANCHES|OPT_PEEPHOLE|OPT_CONST_PROPAGATE|OPT_REMOVE_FEATURES|OPT_MAKE_MACROS)


### PR DESCRIPTION
Yea, another one. Procrastination is powerful today.

This adds a new opt flag wherein it will allow forwarding hub reads over  hub writes that we can be sure aren't aliasing with the one being processed.

It kinda helps a little bit when locals-on-stack is needed, but not as much as I'd hoped. I think there needs to be some check for dead writes, too.

Currently not enabled by any O levels, should perhaps go into -O2?