### PR TITLE
Make more fatfs configs settable

### DIFF
--- a/include/filesys/fatfs/fatfs.cc
+++ b/include/filesys/fatfs/fatfs.cc
@@ -280,6 +280,9 @@ ssize_t v_write(vfs_file_t *fil, void *buf, size_t siz)
     if (!f) {
         return _seterror(EBADF);
     }
+#if FF_FS_READONLY
+    return _seterror(EACCES);
+#else
 #ifdef _DEBUG_FATFS    
     __builtin_printf("v_write: f_write %d bytes:", siz);
 #endif    
@@ -292,6 +295,7 @@ ssize_t v_write(vfs_file_t *fil, void *buf, size_t siz)
         return _set_dos_error(r);
     }
     return x;
+#endif
 }
 off_t v_lseek(vfs_file_t *fil, off_t offset, int whence)
 {
@@ -329,32 +333,48 @@ int v_ioctl(vfs_file_t *fil, unsigned long req, void *argp)
 
 int v_mkdir(const char *name, mode_t mode)
 {
+#if FF_FS_READONLY
+    return _seterror(EACCES);
+#else
     int r;
 
     r = f_mkdir(name);
     return _set_dos_error(r);
+#endif
 }
 
 int v_remove(const char *name)
 {
+#if FF_FS_READONLY
+    return _seterror(EACCES);
+#else
     int r;
 
     r = f_unlink(name);
     return _set_dos_error(r);
+#endif
 }
 
 int v_rmdir(const char *name)
 {
+#if FF_FS_READONLY
+    return _seterror(EACCES);
+#else
     int r;
 
     r = f_unlink(name);
     return _set_dos_error(r);
+#endif
 }
 
 int v_rename(const char *old, const char *new)
 {
+#if FF_FS_READONLY
+    return _seterror(EACCES);
+#else
     int r = f_rename(old, new);
     return _set_dos_error(r);
+#endif
 }
  
 int v_open(vfs_file_t *fil, const char *name, int flags)

--- a/include/filesys/fatfs/ffconf.h
+++ b/include/filesys/fatfs/ffconf.h
@@ -8,7 +8,9 @@
 / Function Configurations
 /---------------------------------------------------------------------------*/
 
+#ifndef FF_FS_READONLY
 #define FF_FS_READONLY	0
+#endif
 /* This option switches read-only configuration. (0:Read/Write or 1:Read-only)
 /  Read-only configuration removes writing API functions, f_write(), f_sync(),
 /  f_unlink(), f_mkdir(), f_chmod(), f_rename(), f_truncate(), f_getfree()
@@ -229,7 +231,9 @@
 / System Configurations
 /---------------------------------------------------------------------------*/
 
+#ifndef FF_FS_TINY
 #define FF_FS_TINY		0
+#endif
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector
@@ -242,7 +246,9 @@
 /  Note that enabling exFAT discards ANSI C (C89) compatibility. */
 
 
+#ifndef FF_FS_NORTC
 #define FF_FS_NORTC		0
+#endif
 #define FF_NORTC_MON	1
 #define FF_NORTC_MDAY	1
 #define FF_NORTC_YEAR	2020


### PR DESCRIPTION
Allows significantly reducing fatfs bloat for read-only usage. FF_FS_TINY and FF_FS_NORTC also help a bit without compromising functionality.