### PR TITLE
Optimize P2 FCACHE loader

### DIFF
--- a/backends/asm/assemble_ir.c
+++ b/backends/asm/assemble_ir.c
@@ -1355,12 +1355,11 @@ DoAssembleIR(struct flexbuf *fb, IR *ir, Module *P)
         break;
     case OPC_FCACHE:
         if (gl_p2) {
-            flexbuf_printf(fb, "\tloc\tpa,\t#(");
+            flexbuf_printf(fb, "\tcallpa\t#(");
             PrintOperandAsValue(fb, ir->dst);
             flexbuf_printf(fb, "-");
             PrintOperandAsValue(fb, ir->src);
-            flexbuf_printf(fb, ")\n");
-            flexbuf_printf(fb, "\tcall\t#FCACHE_LOAD_\n");
+            flexbuf_printf(fb, ")>>2,fcache_load_ptr_\n");
         } else {
             flexbuf_printf(fb, "\tcall\t#LMM_FCACHE_LOAD\n");
             flexbuf_printf(fb, "\tlong\t(");

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -5943,21 +5943,21 @@ static const char *builtin_div_p2 =
 
 const char *builtin_fcache_p2 =
     "FCACHE_LOAD_\n"
-    "    pop\tfcache_tmpb_\n"
-    "    add\tfcache_tmpb_, pa\n"
-    "    push\tfcache_tmpb_\n"
-    "    sub\tfcache_tmpb_, pa\n"
-    "    shr\tpa, #2\n" // convert to words
-    "    altd\tpa\n"
+    "    mov\tfcache_tmpb_,ptrb\n"
+    "    pop\tptrb\n"
+    "    altd\tpa,ret_instr_\n"
     "    mov\t 0-0, ret_instr_\n"
-    "    sub\tpa, #1\n"
     "    setq\tpa\n"
-    "    rdlong\t$0, fcache_tmpb_\n"
+    "    rdlong\t$0, ptrb++\n"
+    "    push\tptrb\n"
+    "    mov ptrb,fcache_tmpb_\n"
     "    jmp\t#\\$0 ' jmp to cache\n"
     "ret_instr_\n"
-    "    ret\n"
+    "    _ret_ cmp inb,#0\n" // Return instruction that also works as an ALTD post-decrement
     "fcache_tmpb_\n"
     "    long 0\n"
+    "fcache_load_ptr_\n"
+    "    long FCACHE_LOAD_\n"
     ;
 
 //


### PR DESCRIPTION
Not sure if saving PTRB here is necessary (do we allow it outside of volatile inline ASM?)