### PR TITLE
Use UTF8 for LFNs by default and make configurable

### DIFF
--- a/include/filesys/fatfs/ffconf.h
+++ b/include/filesys/fatfs/ffconf.h
@@ -140,7 +140,10 @@
 /  ff_memfree() exemplified in ffsystem.c, need to be added to the project. */
 
 
-#define FF_LFN_UNICODE	0
+#ifndef FF_LFN_UNICODE
+#define FF_LFN_UNICODE	2
+#endif
+
 /* This option switches the character encoding on the API when LFN is enabled.
 /
 /   0: ANSI/OEM in current CP (TCHAR = char)


### PR DESCRIPTION
It turns out that LFNs are internally unicode. Setting FF_LFN_UNICODE to 0 just makes it attempt to convert LFNs into the selected codepage, which is silly to begin with since the default runtime encoding for flexspin is UTF-8. The UTF-16/UTF-8 conversion is slightly less obnoxious than the codepage conversions. I think, anyways. Haven't checked. But I did check that it doesn't affect the default 8.3 configuration at all.