### PR TITLE
Inline pure functions when all args are constant

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -1938,6 +1938,15 @@ TransformConstDst(IR *ir, Operand *imm)
         // Z is set if bit is SET
         val1 = ~val1 & (1<<(val2&31));
         break;
+    case OPC_BITH:
+        val1 |= EvalP2BitMask(val2);
+        break;
+    case OPC_BITL:
+        val1 &= ~EvalP2BitMask(val2);
+        break;
+    case OPC_BITNOT:
+        val1 ^= EvalP2BitMask(val2);
+        break;
     default:
         return 0;
     }

--- a/backends/asm/outasm.h
+++ b/backends/asm/outasm.h
@@ -61,7 +61,7 @@ IR *EmitLabel(IRList *list, Operand *op);
 void OptimizeIRLocal(IRList *irl, Function *f);
 void OptimizeIRGlobal(IRList *irl);
 void OptimizeFcache(IRList *irl);
-bool ShouldBeInlined(Function *f);
+bool AnalyzeInlineEligibility(Function *f);
 bool RemoveIfInlined(Function *f);
 int  ExpandInlines(IRList *irl);
 
@@ -121,8 +121,11 @@ typedef struct ir_bedata {
     /* number of local registers that need to be pushed */
     int numsavedregs;
     
-    /* flag for whether we should inline the function */
-    bool isInline;
+    /* flags for whether we should inline the function */
+    unsigned inliningFlags;
+   #define ASM_INLINE_SMALL_FLAG  0x01
+   #define ASM_INLINE_SINGLE_FLAG 0x02
+   #define ASM_INLINE_PURE_FLAG   0x04
 
     /* set after inlining if the function has no external calls left */
     bool effectivelyLeaf;


### PR DESCRIPTION
A pure function here meaning one that only contains ALU ops between locals/args/results and is otherwise inline eligible. The set of allowed ops is a bit small right now, but it can now constant propagate some 64 bit ops (notably shifts):

![image](https://github.com/totalspectrum/spin2cpp/assets/6944842/da7e29b5-d697-4786-bd47-ca7ea47ca42f)


Also included: BITx constant eval