### PR TITLE
Optimize strcasecmp

### DIFF
--- a/include/libc/misc/tolower.c
+++ b/include/libc/misc/tolower.c
@@ -30,5 +30,7 @@ avoid the problem of digressive versions of dLibs.
 int
 tolower(int c)
 {
-  return isupper(c) ? (c ^ 0x20) : c;
+  //return isupper(c) ? (c ^ 0x20) : c;
+  return (unsigned)c - 'A' < 26u ? (c ^ 0x20) : c;
+  
 }

--- a/include/libc/misc/toupper.c
+++ b/include/libc/misc/toupper.c
@@ -26,5 +26,6 @@ avoid the problem of digressive versions of dLibs.
 int
 toupper(int c)
 {
-  return islower(c) ? (c ^ 0x20) : c;
+  // return islower(c) ? (c ^ 0x20) : c;
+  return (unsigned)c - 'a' < 26u ? (c ^ 0x20) : c;
 }

--- a/include/libc/string/strcasecmp.c
+++ b/include/libc/string/strcasecmp.c
@@ -12,7 +12,7 @@
 int				/* <0 for <, 0 for ==, >0 for > */
 strcasecmp(const char *scan1, const char *scan2)
 {
-	register char c1, c2;
+	register int c1, c2;
 
 	if (!scan1)
 		return scan2 ? -1 : 0;
@@ -28,6 +28,8 @@ strcasecmp(const char *scan1, const char *scan2)
 	 * which look negative collate low against normal characters but
 	 * high against the end-of-string NUL.
 	 */
+	// W21: only if char is signed (in flexspin it isn't)
+#if 0
 	if (c1 == c2)
 		return(0);
 	else if (c1 == '\0')
@@ -35,5 +37,6 @@ strcasecmp(const char *scan1, const char *scan2)
 	else if (c2 == '\0')
 		return(1);
 	else
+#endif
 		return(c1 - c2);
 }


### PR DESCRIPTION
I noticed this function got pessimized by the inline change (because functions now become uneligible for inlining if inlining into themselves grows them too large, causing `toupper` to not inline), so I decided to just fix it properly.