### PR TITLE
fix byte[@arr[i]][0] like expressions

### DIFF
--- a/Test/Expect/bctest004.lst
+++ b/Test/Expect/bctest004.lst
@@ -1,0 +1,69 @@
+00 B4 C4 04                   ' CLKFREQ
+6F                            ' CLKMODE
+00                            ' Placeholder for checksum
+10 00                         ' PBASE
+70 00                         ' VBASE
+64 02                         ' DBASE
+28 00                         ' PCURR
+74 02                         ' DCURR
+'--- Object Header for bctest004
+60 00                         ' Object size
+06                            ' Method count + 1
+00                            ' OBJ count
+18 00 08 00                   ' Function direct @0028 (local size 8)
+24 00 08 00                   ' Function override @0034 (local size 8)
+32 00 08 00                   ' Function addrof1 @0042 (local size 8)
+40 00 08 00                   ' Function addrof2 @0050 (local size 8)
+4B 00 04 00                   ' Function addroff_const @005B (local size 4)
+'--- Function direct
+40                            ' MEM_READ LONG VBASE+$0000 (short)
+3F B4                         ' REG_WRITE 1F4(OUTA)
+44                            ' MEM_READ LONG VBASE+$0004 (short)
+3F B4                         ' REG_WRITE 1F4(OUTA)
+64                            ' MEM_READ LONG DBASE+$0004 (short)
+D8 00                         ' MEM_READ LONG VBASE+$0000+(POP index) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+32                            ' RETURN_PLAIN
+'--- Function override
+88 00                         ' MEM_READ BYTE VBASE+$0000 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+88 01                         ' MEM_READ BYTE VBASE+$0001 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+64                            ' MEM_READ LONG DBASE+$0004 (short)
+98 00                         ' MEM_READ BYTE VBASE+$0000+(POP index) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+32                            ' RETURN_PLAIN
+'--- Function addrof1
+64                            ' MEM_READ LONG DBASE+$0004 (short)
+DB 00                         ' MEM_ADDRESS LONG VBASE+$0000+(POP index) 
+36                            ' CONSTANT 1
+90                            ' MEM_READ BYTE (POP base)+(POP index) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+64                            ' MEM_READ LONG DBASE+$0004 (short)
+DB 00                         ' MEM_ADDRESS LONG VBASE+$0000+(POP index) 
+80                            ' MEM_READ BYTE (POP base) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+32                            ' RETURN_PLAIN
+'--- Function addrof2
+64                            ' MEM_READ LONG DBASE+$0004 (short)
+98 00                         ' MEM_READ BYTE VBASE+$0000+(POP index) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+47                            ' MEM_ADDRESS LONG VBASE+$0004 (short)
+64                            ' MEM_READ LONG DBASE+$0004 (short)
+90                            ' MEM_READ BYTE (POP base)+(POP index) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+32                            ' RETURN_PLAIN
+'--- Function addroff_const
+88 00                         ' MEM_READ BYTE VBASE+$0000 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+88 01                         ' MEM_READ BYTE VBASE+$0001 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+47                            ' MEM_ADDRESS LONG VBASE+$0004 (short)
+80                            ' MEM_READ BYTE (POP base) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+47                            ' MEM_ADDRESS LONG VBASE+$0004 (short)
+36                            ' CONSTANT 1
+90                            ' MEM_READ BYTE (POP base)+(POP index) 
+3F B4                         ' REG_WRITE 1F4(OUTA)
+32                            ' RETURN_PLAIN
+00 00 00                      ' (padding)

--- a/Test/bctest004.spin
+++ b/Test/bctest004.spin
@@ -1,0 +1,29 @@
+VAR
+  long arr[123]
+
+
+PUB direct(i)
+outa := arr[0]
+outa := arr[1]
+outa := arr[i]
+
+PUB override(i)
+outa := arr.byte[0]
+outa := arr.byte[1]
+outa := arr.byte[i]
+
+PUB addrof1(i)
+
+outa := byte[@arr[i]][1]
+outa := byte[@arr[i]][0] ' <- bugs used to be here
+
+pub addrof2(i)
+
+outa := byte[@arr[0]][i]
+outa := byte[@arr[1]][i] ' <- currently not optimal
+
+pub addroff_const
+outa := byte[@arr[0]][0]
+outa := byte[@arr[0]][1]
+outa := byte[@arr[1]][0] ' <- currently not optimal
+outa := byte[@arr[1]][1] ' <- currently not optimal

--- a/backends/bytecode/outbc.c
+++ b/backends/bytecode/outbc.c
@@ -3147,9 +3147,8 @@ BCPrepareObject(Module *P) {
                 //printf("Got obj of type %s named %s\n",((Module*)var->left->d.ptr)->classname,var->right->left->d.string);
                 arrsize = 1;
             } else if (var->right->left->kind == AST_ARRAYDECL) {
-                ASSERT_AST_KIND(var->right->left->right,AST_INTEGER,return;);
-                DEBUG(NULL,"Got obj array of type %s, size %lu named %s",((Module*)var->left->d.ptr)->classname,(unsigned long)(var->right->left->right->d.ival),var->right->left->left->d.string);
-                arrsize = var->right->left->right->d.ival;
+                arrsize = EvalConstExpr(var->right->left->right);
+                DEBUG(NULL,"Got obj array of type %s, size %d named %s",((Module*)var->left->d.ptr)->classname,arrsize,var->right->left->left->d.string);
             } else {
                 ERROR(var->right,"Unhandled OBJ AST kind %d",var->right->left->kind);
             }

--- a/backends/bytecode/outbc.c
+++ b/backends/bytecode/outbc.c
@@ -583,11 +583,10 @@ BCCompileMemOpExEx(BCIRBuffer *irbuf,AST *node,BCContext context, enum MemOpKind
         }
     } else if (ident->kind == AST_MEMREF) {
         if (!typeoverride && ident->right->kind == AST_ADDROF && 
-        ident->right->left && ident->right->left->kind == AST_ARRAYREF && (!indexExpr || IsConstZero(indexExpr) || IsConstZero(ident->right->left->right))) {
+        ident->right->left && ident->right->left->kind == AST_ARRAYREF && IsConstZero(ident->right->left->right)) {
             // Handle weird AST representation of "var.byte[x]""
             DEBUG(node,"handling size override kind 1...");
             typeoverride = ident->left;
-            if (!IsConstZero(ident->right->left->right)) indexExpr = ident->right->left->right;
             ident = ident->right->left->left;
             goto try_ident_again;
         } else if (!typeoverride && ident->right->kind == AST_ADDROF && IsIdentifier(ident->right->left)) {

--- a/frontends/common.c
+++ b/frontends/common.c
@@ -952,7 +952,7 @@ void
 DEBUG(AST *instr, const char *msg, ...)
 {
     va_list args;
-    if (gl_verbosity <= 1) return;
+    if (gl_verbosity <= 0) return;
     LineInfo *info = GetLineInfo(instr);
 
     SETCOLOR(PRINT_DEBUG);


### PR DESCRIPTION
This code very much confuses me. There's some cases that still aren't properly optimal (see test), but IDK this is all garbage and there's 3 variables to keep track of the type, so I just did the minimal fix to get correct behaviour.