### PR TITLE
Add "repeat n : var" statement from the future

### DIFF
--- a/frontends/common.h
+++ b/frontends/common.h
@@ -27,6 +27,7 @@ typedef enum SpinExprState {
     ExprState_LookUpPending,
     ExprState_LookUpDown,
     ExprState_Conditional,
+    ExprState_Repeat,
 } SpinExprState;
 
 /*

--- a/frontends/lexer.c
+++ b/frontends/lexer.c
@@ -878,12 +878,17 @@ parseSpinIdentifier(LexStream *L, AST **ast_ptr, const char *prefix)
                 break;
             case SP_IFNOT:
             case SP_ELSEIFNOT:
-            case SP_REPEAT:
             case SP_CASE:
             case SP_CASE_FAST:
                 if (!InDatBlock(L)) {
                     EstablishIndent(L, startColumn);
                 }
+                break;
+            case SP_REPEAT:
+                if (!InDatBlock(L)) {
+                    EstablishIndent(L, startColumn);
+                }
+                PushExprState(L, ExprState_Repeat);
                 break;
             case SP_LONG:
             case SP_BYTE:
@@ -1973,6 +1978,9 @@ getSpinToken(LexStream *L, AST **ast_ptr)
                 PopExprState(L);
             } else if (curState == ExprState_Conditional) {
                 c = SP_CONDITIONAL_SEP;
+                PopExprState(L);
+            } else if (curState == ExprState_Repeat) {
+                c = SP_REPEAT_SEP;
                 PopExprState(L);
             }
         }

--- a/frontends/spin/spin.y
+++ b/frontends/spin/spin.y
@@ -312,6 +312,7 @@ FixupList(AST *list)
 %token SP_LOOK_SEP   ": after lookup/down"
 %token SP_CONDITIONAL  "?"
 %token SP_CONDITIONAL_SEP ": after ?"
+%token SP_REPEAT_SEP ": after repeat"
 
 %token SP_FADD   "+."
 %token SP_FSUB   "-."
@@ -789,6 +790,14 @@ repeatstmt:
       to = NewAST(AST_TO, $6, step);
       from = NewAST(AST_FROM, $4, to);
       $$ = NewCommentedAST(AST_COUNTREPEAT, $2, from, $1);
+    }
+  | SP_REPEAT expr SP_REPEAT_SEP identifier SP_EOLN stmtblock
+    {
+      AST *body = CheckYield($6);
+      AST *step = NewAST(AST_STEP,AstInteger(1),body);
+      AST *to = NewAST(AST_TO, AstOperator('-',$2,AstInteger(1)), step);
+      AST *from = NewAST(AST_FROM, AstInteger(0), to);
+      $$ = NewCommentedAST(AST_COUNTREPEAT, $4, from, $1);
     }
   | SP_REPEAT expr SP_EOLN stmtblock
     {


### PR DESCRIPTION
This is mentioned in the Spin2 doc as a feature for PNut v40 that hasn't been released yet.

Thought it was simple to add, so I did.