### PR TITLE
Fix Spin transform level for CASE

### DIFF
--- a/Test/Expect/test169.cpp
+++ b/Test/Expect/test169.cpp
@@ -1,0 +1,37 @@
+#include <stdlib.h>
+#define __SPIN2CPP__
+#include <propeller.h>
+#include "test169.h"
+
+void test169::Func1(int32_t A, int32_t B)
+{
+  int32_t 	_tmp__0000;
+  _tmp__0000 = abs((A % 3));
+  if (_tmp__0000 == 0) {
+    goto _case__0002;
+  }
+  if (_tmp__0000 == 1) {
+    goto _case__0003;
+  }
+  if (_tmp__0000 == 2) {
+    goto _case__0004;
+  }
+  if (_tmp__0000 == (abs(B))) {
+    goto _case__0005;
+  }
+  goto _endswitch_0001;
+  _case__0002: ;
+  _OUTA = 1;
+  goto _endswitch_0001;
+  _case__0003: ;
+  _OUTA = 2;
+  goto _endswitch_0001;
+  _case__0004: ;
+  _OUTA = 3;
+  goto _endswitch_0001;
+  _case__0005: ;
+  _OUTA = 4;
+  goto _endswitch_0001;
+  _endswitch_0001: ;
+}
+

--- a/Test/Expect/test169.h
+++ b/Test/Expect/test169.h
@@ -1,0 +1,12 @@
+#ifndef test169_Class_Defined__
+#define test169_Class_Defined__
+
+#include <stdint.h>
+
+class test169 {
+public:
+  static void 	Func1(int32_t A, int32_t B);
+private:
+};
+
+#endif

--- a/Test/test169.spin
+++ b/Test/test169.spin
@@ -1,0 +1,8 @@
+
+PUB func1(a,b)
+
+case ||(a//3)
+    0: outa := 1
+    1: outa := 2
+    2: outa := 3
+    ||b: outa := 4

--- a/frontends/spin/spinlang.c
+++ b/frontends/spin/spinlang.c
@@ -653,7 +653,7 @@ doSpinTransform(AST **astptr, int level, AST *parent)
     {
         AST *list = ast->right;
         const char *case_name = ast->kind == AST_CASETABLE ? "case_fast" : NULL;
-        doSpinTransform(&ast->left, level, ast);
+        doSpinTransform(&ast->left, 0, ast);
         AstReportAs(ast, &saveinfo); // any newly created AST nodes should reflect debug info from this one
 #ifdef NEVER // handled in CreateSwitch now        
         if (ast->left->kind != AST_IDENTIFIER && ast->left->kind != AST_ASSIGN) {
@@ -667,7 +667,7 @@ doSpinTransform(AST **astptr, int level, AST *parent)
             ASSERT_AST_KIND(list,AST_STMTLIST,);
 
             caseitem = list->left;
-            doSpinTransform(&caseitem->left, level, ast);
+            doSpinTransform(&caseitem->left, 0, ast);
             doSpinTransform(&caseitem->right, level, ast);
             list = list->right;
         }

--- a/frontends/spin/spinlang.c
+++ b/frontends/spin/spinlang.c
@@ -667,7 +667,7 @@ doSpinTransform(AST **astptr, int level, AST *parent)
             ASSERT_AST_KIND(list,AST_STMTLIST,);
 
             caseitem = list->left;
-            doSpinTransform(&caseitem->left, 0, ast);
+            doSpinTransform(&caseitem->left, level, ast);
             doSpinTransform(&caseitem->right, level, ast);
             list = list->right;
         }


### PR DESCRIPTION
Fixes error (bytecode backend) or weird codegen (ASM backend) where unary operators are used in CASE (and also the case item expressions, though I haven't actually tested that)