### PR TITLE
Move only variables whose address is actually taken to stack

### DIFF
--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -31,8 +31,8 @@
 #define IS_FAST_CALL(f) ( (f == 0) || !FuncData(f) || FuncData(f)->convention == FAST_CALL)
 #define IS_STACK_CALL(f) ( (f != 0) && FuncData(f)->convention == STACK_CALL)
 
-#define ALL_VARS_ON_STACK(f) ( IS_STACK_CALL(f) || f->local_address_taken || f->closure)
-#define ANY_VARS_ON_STACK(f) ( ALL_VARS_ON_STACK(f) || f->stack_local )
+#define ALL_VARS_ON_STACK(f) ( IS_STACK_CALL(f) || f->force_locals_to_stack || (f->local_address_taken && IsSpinLang(f->language)) || f->closure)
+#define ANY_VARS_ON_STACK(f) ( ALL_VARS_ON_STACK(f) || f->stack_local || f->local_address_taken)
 
 #define IS_LEAF(func) ((gl_compress == 0) && ((func)->is_leaf || (FuncData(func) && FuncData(func)->effectivelyLeaf)))
 
@@ -297,6 +297,9 @@ PutVarOnStack(Function *func, Symbol *sym, int size)
         return false;
     }
     if (sym->kind == SYM_LOCALVAR && TypeGoesOnStack((AST *)sym->v.ptr)) {
+        return true;
+    }
+    if (sym->flags & SYMF_ADDRESSABLE) {
         return true;
     }
     return false;

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -31,7 +31,7 @@
 #define IS_FAST_CALL(f) ( (f == 0) || !FuncData(f) || FuncData(f)->convention == FAST_CALL)
 #define IS_STACK_CALL(f) ( (f != 0) && FuncData(f)->convention == STACK_CALL)
 
-#define ALL_VARS_ON_STACK(f) ( IS_STACK_CALL(f) || f->force_locals_to_stack || (f->local_address_taken && IsSpinLang(f->language)) || f->closure)
+#define ALL_VARS_ON_STACK(f) ( IS_STACK_CALL(f) || f->force_locals_to_stack || (f->local_address_taken && IsSpinLang(f->language) && !(f->optimize_flags & OPT_SPIN_STRICTMEM)) || f->closure)
 #define ANY_VARS_ON_STACK(f) ( ALL_VARS_ON_STACK(f) || f->stack_local || f->local_address_taken)
 
 #define IS_LEAF(func) ((gl_compress == 0) && ((func)->is_leaf || (FuncData(func) && FuncData(func)->effectivelyLeaf)))

--- a/backends/dat/outdat.c
+++ b/backends/dat/outdat.c
@@ -924,7 +924,7 @@ SpecialRdOperand(AST *ast, uint32_t opimm)
         // fits in $00-$ff
         val = EvalPasmExpr(ast);
         if ( (val > 0xff) && 0 == (opimm & BIG_IMM_SRC) ) {
-            WARNING(ast, "immediate value out of range");
+            ERROR(ast, "immediate value out of range");
         }
     }
     val = 0;

--- a/cmdline.c
+++ b/cmdline.c
@@ -538,6 +538,7 @@ static FlagTable optflag[] = {
     { "local-reuse", OPT_LOCAL_REUSE},
     { "aggressive-mem", OPT_AGGRESSIVE_MEM},
     { "cold-code", OPT_COLD_CODE},
+    { "spin-strict-memory", OPT_SPIN_STRICTMEM},
     
     { "experimental", OPT_EXPERIMENTAL },
     { "all", OPT_FLAGS_ALL },

--- a/frontends/basic/basiclang.c
+++ b/frontends/basic/basiclang.c
@@ -927,12 +927,17 @@ doBasicTransform(AST **astptr, bool transformFuncall)
     {
         doBasicTransform(&ast->left, transformFuncall);
         doBasicTransform(&ast->right, transformFuncall);
-        if (IsLocalVariable(ast->left)) {
+        Symbol *sym;
+        if (IsLocalVariableEx(ast->left,&sym)) {
             curfunc->local_address_taken = 1;
+            if (sym) {
+                sym->flags |= SYMF_ADDRESSABLE;
+            } else {
+                curfunc->force_locals_to_stack = 1; // Fallback if we couldn't get a symbol
+            }
         }
         // taking the address of a function may restrict how
         // we can call it (stack vs. register calling)
-        Symbol *sym;
         Function *f = NULL;
         sym = FindCalledFuncSymbol(ast, NULL, 0);
         if (sym && sym->kind == SYM_FUNCTION) {
@@ -997,7 +1002,7 @@ doBasicTransform(AST **astptr, bool transformFuncall)
         doBasicTransform(&ast->right, transformFuncall);
         // keep local variables on stack, so they will be preserved
         // if an exception throws us back here without cleanup
-        curfunc->local_address_taken = 1;
+        curfunc->force_locals_to_stack = 1;
         break;
     case AST_READ:
         doBasicTransform(&ast->left, transformFuncall);

--- a/frontends/common.h
+++ b/frontends/common.h
@@ -450,6 +450,7 @@ typedef struct funcdef {
     unsigned cog_task:1;     // 1 if function is started in another cog
     unsigned used_as_ptr:1;  // 1 if function's address is taken as a pointer
     unsigned local_address_taken: 1; // 1 if a local variable or parameter has its address taken
+    unsigned force_locals_to_stack: 1; // 1 if function must store all locals on the stack
     unsigned no_inline:1;    // 1 if function cannot be inlined
     unsigned prefer_inline:1; // 1 if function should be inlined more often
     unsigned is_leaf:1;      // 1 if function is a leaf function
@@ -978,6 +979,7 @@ AST *GetComments(void);
 
 /* is an AST identifier a local variable? */
 bool IsLocalVariable(AST *ast);
+bool IsLocalVariableEx(AST *ast, Symbol **symout);
 
 /* push the current types identifier */
 void PushCurrentTypes(void);

--- a/frontends/common.h
+++ b/frontends/common.h
@@ -193,9 +193,10 @@ extern int gl_optimize_flags; /* flags for optimization */
 #define OPT_AGGRESSIVE_MEM      0x00200000  /* aggressive load/store optimization */
 #define OPT_COLD_CODE           0x00400000  /* move cold code to end of function */
 #define OPT_MERGE_DUPLICATES    0x00800000  /* merge duplicate functions */
+#define OPT_SPIN_STRICTMEM      0x01000000  /* strict memory semantics for Spin */
 
 #define OPT_EXPERIMENTAL        0x80000000  /* gate new or experimental optimizations */
-#define OPT_FLAGS_ALL           0xffffffff
+#define OPT_FLAGS_ALL           0xffffffff & ~OPT_SPIN_STRICTMEM
 
 #define OPT_ASM_BASIC  (OPT_BASIC_REGS|OPT_BRANCHES|OPT_PEEPHOLE|OPT_CONST_PROPAGATE|OPT_REMOVE_FEATURES|OPT_MAKE_MACROS)
 

--- a/frontends/types.c
+++ b/frontends/types.c
@@ -909,8 +909,14 @@ static AST *ScalePointer(AST *type, AST *val)
 // return the address of an array
 AST *ArrayAddress(AST *expr)
 {
-    if (curfunc && IsLocalVariable(expr)) {
+    Symbol *sym;
+    if (curfunc && IsLocalVariableEx(expr,&sym)) {
         curfunc->local_address_taken = 1;
+        if (sym) {
+            sym->flags |= SYMF_ADDRESSABLE;
+        } else {
+            curfunc->force_locals_to_stack = 1; // Fallback if we couldn't get a symbol
+        }
     }
     return NewAST(AST_ABSADDROF,
                   NewAST(AST_ARRAYREF, expr, AstInteger(0)),
@@ -1333,8 +1339,14 @@ AST *CoerceAssignTypes(AST *line, int kind, AST **astptr, AST *desttype, AST *sr
             *astptr = copy;
         } else {
             *astptr = NewAST(AST_ADDROF, expr, NULL);
-            if (curfunc && IsLocalVariable(expr)) {
+            Symbol *sym;
+            if (curfunc && IsLocalVariableEx(expr,&sym)) {
                 curfunc->local_address_taken = 1;
+                if (sym) {
+                    sym->flags |= SYMF_ADDRESSABLE;
+                } else {
+                    curfunc->force_locals_to_stack = 1; // Fallback if we couldn't get a symbol
+                }
             }
         }
         srctype = NewAST(AST_REFTYPE, srctype, NULL);

--- a/symbol.h
+++ b/symbol.h
@@ -63,6 +63,7 @@ typedef struct symbol {
 #define SYMF_PRIVATE  0x02  /* symbol should not be used from other modules */
 #define SYMF_INTERNAL 0x04  /* symbol is created by flexspin itself, should not be shown in listings */
 #define SYMF_NOALLOC  0x08  /* symbol should not be allocated */
+#define SYMF_ADDRESSABLE 0x10 /* symbol has its address taken and therefore must exist in memory */
 
 #define INTVAL(sym) ((sym)->v.i)
 


### PR DESCRIPTION
(For C and BASIC only)

Haven't super-tested this, but this chops a couple Kbytes off the libc / FatFs driver.

It also still allocates the same size stack frame, so that should perhaps be fixed still.
