### PR TITLE
Reclaim 88 bytes of bloat in v_stat

### DIFF
--- a/include/filesys/fatfs/fatfs.cc
+++ b/include/filesys/fatfs/fatfs.cc
@@ -241,7 +241,7 @@ int v_stat(const char *name, struct stat *buf)
     buf->st_nlink = 1;
     buf->st_size = finfo.fsize;
     buf->st_blksize = 512;
-    buf->st_blocks = (buf->st_size + 511) / 512;
+    buf->st_blocks = (finfo.fsize + 511) / 512;
     buf->st_atime = buf->st_mtime = buf->st_ctime = unixtime(finfo.fdate, finfo.ftime);
 #ifdef _DEBUG_FATFS
     __builtin_printf("v_stat returning %d mode=0x%x\n", r, buf->st_mode);


### PR DESCRIPTION
... caused by careless 64-bit type usage.

(Extra weighty because there's no divide->bitshift optimization for 64 bit types)