### PR TITLE
Fix lseek off_t type confusion

### DIFF
--- a/include/libc.a
+++ b/include/libc.a
@@ -3,7 +3,7 @@
 #define wint_t int
 #define time_t unsigned int
 #define mode_t unsigned int
-#define off_t long
+#define off_t long long
 #define _FILE struct s_vfs_file_t
 #define DIR struct _dir
 #define DIRENT struct dirent


### PR DESCRIPTION
This makes the filesystem work at all again when used from Spin.

We should really have a "dev" branch so current commit on master is never completely broken like this.

Though I'm not quite on board with the idea of off_t being 64 bit by default (since without extra defines the only FS impl possibly capable of large files is 9P and that's very niche, esp. if you take into consideration how slow 9P is).