### PR TITLE
Change unrecognized optimization flag to warning

### DIFF
--- a/cmdline.c
+++ b/cmdline.c
@@ -603,8 +603,7 @@ int ParseOptimizeString(AST *line, const char *str, int *flag_ptr)
             }
         }
         if (!bits) {
-            ERROR(line, "Unrecognized optimization flag: %s", buf);
-            return 0;
+            WARNING(line, "Unrecognized optimization flag: %s", buf);
         }
         if (notflag) {
             flags &= ~bits;


### PR DESCRIPTION
When a new optimization flag is introduced, any source code or script that refers to them becomes backwards-incompatible with previous compiler versions. This can become a bit annoying.