### PR TITLE
Add 3rd-party project integration test job

### DIFF
--- a/.github/workflows/build_n_test.yml
+++ b/.github/workflows/build_n_test.yml
@@ -88,6 +88,8 @@ jobs:
             /*
             !*.RAW
             !*.VU
+            !*.gif
+            !*.png
       - name: Compile Spin Hexagon
         run: rake
         working-directory: hexagon_p1

--- a/.github/workflows/build_n_test.yml
+++ b/.github/workflows/build_n_test.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   build_win32:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install MinGW
         run: "sudo apt-get install gcc-mingw-w64-i686"
@@ -26,8 +26,9 @@ jobs:
         with:
           name: release_zips_win32
           path: "./*.zip"
+  
   build_linux_amd64:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Install musl-gcc
         run: "sudo apt-get install musl-tools"
@@ -42,16 +43,18 @@ jobs:
         with:
           name: release_zips_linux_amd64
           path: "./*.zip"
+  
   test_offline:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
       - name: make
         run: make
       - name: test
         run: make test_offline
+  
   test_spinsim:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -61,4 +64,54 @@ jobs:
         run: make
       - name: test
         run: make test_spinsim
+  
+  test_3rdparty:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Grab utilities
+        run: "sudo apt-get install rake"
+      - name: Fetch spin2cpp
+        uses: actions/checkout@v4
+        with:
+          path: spin2cpp
+      - name: Build flexspin
+        run: make -j "OPT=-O2 -march=native"
+        working-directory: spin2cpp
+
+      - name: Fetch Spin Hexagon
+        uses: actions/checkout@v4
+        with:
+          repository: IRQsome/Spin-Hexagon
+          path: hexagon_p1
+          sparse-checkout-cone-mode: false
+          sparse-checkout: | # Avoid grabbing large audio files
+            /*
+            !*.RAW
+            !*.VU
+      - name: Compile Spin Hexagon
+        run: rake
+        working-directory: hexagon_p1
+        env:
+          FASTSPIN_NAME: ${{github.workspace}}/spin2cpp/build/flexspin
+
+      - name: Fetch MegaYume
+        uses: actions/checkout@v4
+        with:
+          repository: IRQsome/MegaYume
+          path: megayume
+      - name: Compile MegaYume
+        run: ./build_comptest.sh
+        working-directory: megayume
+
+      - name: Fetch NeoYume
+        uses: actions/checkout@v4
+        with:
+          repository: IRQsome/NeoYume
+          path: neoyume
+      - name: Compile NeoYume
+        run: ./build_comptest.sh
+        working-directory: neoyume
+
+
+
 


### PR DESCRIPTION
Add a new test job that pulls in some big 3rd-party projects (read: mine) off github and sees if they compile at all.

I found all three of the projects I added in to be broken today:
 - MegaYume broke from the fcache size increase (fixed on my end)
 - NeoYume had #465
 - SpinHexagon is still broken (bad ASM output from compiler backend, see #468 )

So there's certainly merit to this idea that doesn't just stem from me specifically being annoyed at my code breaking for dubious reasons.


Also upgrade all the other jobs to Ubuntu 24.04 to ̸p̶l͞e̸a͢sȩ ͘t͜he cr͜uel,̢ únrele҉nti̴ng p̨as̡ságe ̶o͟f ͞tim҉e t́h͡at̛ ͝w̸i̧ll e͜vent҉u̵a͏l͞ly ͏s̸t҉rip͜ ͢us͡ ̨of ̕eve̛ry̴t̵hing w͏e ho̴l̡d d͠ear,҉ t̨he̛ et͞ern̡al̨ tread̨m̛ill ͜prom̛isi̧n͢g͘ us͠ ̴s̴al͟va̵tio͡n ̸b̡ưt ̀on̷l̀y ̀l̸eadi̢n̢g ҉us̸ f̨urt͠he͟r̕ i͟n҉to ̕d̶a̡rk҉n̢e͘s͜s