### PR TITLE
Fix inline register reuse bug

### DIFF
--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -669,7 +669,11 @@ void ReplaceIRWithInline(IRList *irl, IR *origir, Function *func)
 
     static unsigned inlineNum = 0;
     char prefix[64];
-    snprintf(prefix,64-1,"_inline%d_",++inlineNum);
+    if (curfunc->optimize_flags & OPT_LOCAL_REUSE) {
+        snprintf(prefix,64-1,"_inline%d_",++inlineNum);
+    } else {
+        strcpy(prefix,"_inline_");
+    }
 
     DeleteIR(irl, origir);
     if (cond != COND_TRUE) {

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -666,7 +666,10 @@ void ReplaceIRWithInline(IRList *irl, IR *origir, Function *func)
     IR *ir;
     IRCond cond = origir->cond;
     Operand *condlbl = NULL;
-    static char *prefix = "_inline_";
+
+    static unsigned inlineNum = 0;
+    char prefix[64];
+    snprintf(prefix,64-1,"_inline%d_",++inlineNum);
 
     DeleteIR(irl, origir);
     if (cond != COND_TRUE) {


### PR DESCRIPTION
Bug happens like this:
- Leaf functions all get the same set of pre-rename \_tmpXXX\_ registers
- First pass of inline expansion grabs a leaf function with such a temp register, which is thoughtfully renamed to \_inline__tmpXXX\_
- Register reuse pass re-uses the temp register across another such leaf function call
- Second pass of inline expansion expands this call
- whatever register-reuse placed into the temp register is clobbered by the expanded inline IR

Could also happen between two calls of the same non-leaf function, so I simply gave each inline expansion it's own register (only if local-reuse is actually enabled, because otherwise the number of allocated regs blows up)