### PR TITLE
Better fix for throw argument thing (I think)

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -5550,10 +5550,6 @@ AnalyzeInlineEligibility(Function *f)
     return FuncData(f)->inliningFlags & ~prev_flags;
 }
 
-static inline void updateMax(int *dst, int src) {
-    if (*dst < src) *dst = src;
-}
-
 static bool
 ShouldExpandPureFunction(IR *ir) {
     Function *f = (Function *)ir->aux;

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -982,7 +982,7 @@ static bool FuncUsesArgEx(Operand *func, Operand *arg, bool actually)
         return !actually;
     } else if (func && func->val && peek_into_func) {
         Function *funcObj = (Function *)func->val;
-        if ((/*func->kind == IMM_COG_LABEL ||*/ func->kind == IMM_HUB_LABEL) && (actually || funcObj->is_leaf || FuncData(funcObj)->effectivelyLeaf) && !funcObj->has_throw) {
+        if ((/*func->kind == IMM_COG_LABEL ||*/ func->kind == IMM_HUB_LABEL) && (actually || funcObj->is_leaf || FuncData(funcObj)->effectivelyLeaf)) {
             if (arg->kind != REG_ARG) return true; // subreg or smth
             if (arg->val < funcObj->numparams) return true; // Arg used;
             if (!actually && arg->val < FuncData(funcObj)->maxInlineArg) return true; // Arg clobbered
@@ -5605,7 +5605,7 @@ ExpandInlines(IRList *irl)
         ir = ir_next;
     }
     // If inlining (or previous dead-code optimization...) removed all external calls, mark as leaf.
-    if (non_inline_calls==0 && !curfunc->is_leaf && !FuncData(curfunc)->effectivelyLeaf && !curfunc->has_throw) {
+    if (non_inline_calls==0 && !curfunc->is_leaf && !FuncData(curfunc)->effectivelyLeaf) {
         FuncData(curfunc)->effectivelyLeaf = true;
         change = true;
     }

--- a/backends/asm/outasm.c
+++ b/backends/asm/outasm.c
@@ -5266,6 +5266,7 @@ static void CompileStatement(IRList *irl, IRList *cold_irl, AST *ast)
         EmitMove(irl, GetArgReg(1), op, ast);
         EmitMove(irl, GetArgReg(2), NewImmediate(ast->d.ival), ast);
         EmitOp1(irl, OPC_CALL, longjmpfunc);
+        updateMax(&FuncData(curfunc)->maxInlineArg,3);
         break;
     case AST_LABEL:
         EmitDebugComment(irl, ast);

--- a/util/util.h
+++ b/util/util.h
@@ -83,4 +83,9 @@ size_t to_utf8(char *s, wchar_t wcorig);
 // convert utf-8 sequence to wide character; n is max size of cptr
 size_t from_utf8(wchar_t *wcptr, const char *cptr, size_t n);
 
+
+static inline void updateMax(int *dst, int src) {
+    if (*dst < src) *dst = src;
+}
+
 #endif


### PR DESCRIPTION
There is neither a bug tracker entry, a test case nor a description of what the problem was, so I'm assuming the problem was just the generation of Arg registers unrelated to a normal function call and this fixes it more properly.