### PR TITLE
Fix (v)snprintf return values

### DIFF
--- a/include/libc/stdio/sprintf.c
+++ b/include/libc/stdio/sprintf.c
@@ -46,7 +46,7 @@ int snprintf(char *buf, size_t size, const char *fmt, ...)
         S.ptr--;
     }
     S.sputc(0);
-    return r+1;
+    return r;
 }
 
 int vsprintf(char *buf, const char *fmt, va_list ap)
@@ -74,5 +74,5 @@ int vsnprintf(char *buf, size_t size, const char *fmt, va_list ap)
         S.ptr--;
     }
     S.sputc(0);
-    return r+1;
+    return r;
 }


### PR DESCRIPTION
Fix for https://github.com/totalspectrum/flexprop/issues/98

Really strange that only those two have the +1. All other printf variants return r directly. Probably also saves 1 instruction in the code, so that's always nice.