### PR TITLE
Fix Spin2 ABORT/CATCH

### DIFF
--- a/frontends/spin/spinlang.c
+++ b/frontends/spin/spinlang.c
@@ -560,7 +560,7 @@ doSpinTransform(AST **astptr, int level, AST *parent)
         // and can't differentiate a normal return from an abort.
         if (gl_output != OUTPUT_BYTECODE /*|| gl_interp_kind == INTERP_KIND_NUCODE */ ) {
             AST *defaultval = IsSpin2Lang(curfunc->language) ?
-                AstInteger(0) : ast->left;
+                AstOperator(K_BOOL_AND,ast->left,AstInteger(0)) : ast->left;
             curfunc->force_locals_to_stack = 1; // if we do a catch we will want data on stack
             AstReportAs(ast, &saveinfo); // any newly created AST nodes should reflect debug info from this one
             *astptr = ast = NewAST(AST_TRYENV,


### PR DESCRIPTION
This became chuper broken at 98e32c2e005b6ecf6a4f35004140771a7114bdb4 when you tried to correct the return value (I still think the way Spin2 does it is really stupid). If you never evaluate `ast->left`, that actually gets rid of the whole call I'm trying to do, ooops!

Maybe using the bool operator is a bit of a hack, but codegen seems fine to me.

This broke the Spin Hexagon P2 port.