### PR TITLE
Actually allow setting _SIMPLE_IO manually

### DIFF
--- a/include/libsys/fmt.h
+++ b/include/libsys/fmt.h
@@ -9,7 +9,7 @@
 #include <errno.h>
 
 #define INCLUDE_FLOATS
-#undef _SIMPLE_IO
+//#undef _SIMPLE_IO
 
 #ifdef __FLEXC__
 


### PR DESCRIPTION
The `#define INCLUDE_FLOATS` next to that is a bit suspect, too, but that feature appears to actually work, so idk.