### PR TITLE
Fix crash reported by evanh and add extra safety check

### DIFF
--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -3710,7 +3710,7 @@ OptimizePeepholes(IRList *irl)
                     if (test_is_z && InstrUsesFlags(testir, FLAG_WC)) {
                         changeok = false;
                     } else if (InstrSetsAnyFlags(testir)) {
-                        changeok = sawir;
+                        changeok = sawir && (test_is_c || !FlagsUsedAt(testir->prev,FLAG_WZ));
                         lastir = testir;
                         break;
                     }
@@ -3726,7 +3726,7 @@ OptimizePeepholes(IRList *irl)
                         {
                             ReplaceZWithNC(testir);
                         }
-                        if (IsBranch(lastir)) {
+                        if (lastir != NULL && IsBranch(lastir)) {
                             ReplaceZWithNC(lastir);
                         }
                     }

--- a/backends/asm/optimize_ir.c
+++ b/backends/asm/optimize_ir.c
@@ -3710,7 +3710,7 @@ OptimizePeepholes(IRList *irl)
                     if (test_is_z && InstrUsesFlags(testir, FLAG_WC)) {
                         changeok = false;
                     } else if (InstrSetsAnyFlags(testir)) {
-                        changeok = sawir && (test_is_c || !FlagsUsedAt(testir->prev,FLAG_WZ));
+                        changeok = sawir && (test_is_c || !FlagsUsedAt(testir,FLAG_WZ));
                         lastir = testir;
                         break;
                     }


### PR DESCRIPTION
The second change is the crash fix (to stop at the end of the IRList).

The first change fixes a hypothetical problem where we convert a Z to NC conversion and the Z flag is used after the next flag set. (I think this code predated my work that enabled crazy composite conditionals)